### PR TITLE
Add P1 epic agent instructions (SCH-22, SCH-23) and update AGENTS.md

### DIFF
--- a/.agent/epics/SCH-22-rich-alerts-dashboard-analytics.md
+++ b/.agent/epics/SCH-22-rich-alerts-dashboard-analytics.md
@@ -1,0 +1,232 @@
+# SCH-22: Rich Alerts & Dashboard Analytics
+
+> **Linear**: [SCH-22](https://linear.app/schtvr/issue/SCH-22/epic-p1-rich-alerts-and-dashboard-analytics)
+> **Milestone**: P1: First follow-up
+> **Wave**: 5 (all P0 complete; parallel with SCH-23)
+> **Depends on**: P0 complete — specifically SCH-16 (SignalEvent + Discord client), SCH-18 (snapshot persistence), SCH-17 (dashboard stylekit), SCH-21 (snapshot retention)
+
+## Objective
+
+Upgrade the operator experience from P0's minimal `ticker | signal` Discord messages to rich actionable payloads with rationale, levels, and links. Extend the dashboard with performance charts and historical metrics built on top of P0's snapshot history.
+
+## Scope
+
+### Discord rich payloads (`internal/discord/`)
+
+Extend the P0 Discord client (from SCH-16) to support rich embeds:
+
+**Message format** — Discord embed with structured fields:
+
+```go
+type RichAlert struct {
+    SignalEvent  signal.SignalEvent  // from P0
+    Rationale    string              // why the signal fired (human-readable)
+    Levels       AlertLevels         // key price levels
+    Links        []AlertLink         // relevant links (chart, news, etc.)
+    SizingClass  string              // optional: "small", "medium", "large"
+    PortfolioCtx PortfolioContext    // position size, portfolio weight
+}
+
+type AlertLevels struct {
+    Current    float64
+    EntryAvg   float64
+    Support    float64  // optional, 0 if unknown
+    Resistance float64  // optional, 0 if unknown
+}
+
+type AlertLink struct {
+    Label string
+    URL   string
+}
+
+type PortfolioContext struct {
+    PositionSize  float64  // market value
+    PortfolioWeight float64  // percentage of net liq
+    DayPL         float64
+    TotalPL       float64
+}
+```
+
+**Discord embed structure**:
+
+```
+┌──────────────────────────────────────────┐
+│ 🔴 AAPL | 5% Price Drop                 │
+│                                          │
+│ **Rationale**: Position dropped 5.2%     │
+│ from avg cost of $150.25                 │
+│                                          │
+│ Current   │ Entry Avg │ Day P&L          │
+│ $142.40   │ $150.25   │ -$782.50         │
+│                                          │
+│ Portfolio weight: 14.2% ($14,240)        │
+│                                          │
+│ 📊 Chart | 📰 News                       │
+├──────────────────────────────────────────┤
+│ morgans-d-stonks • 2026-04-15 15:30 ET   │
+└──────────────────────────────────────────┘
+```
+
+**Requirements**:
+
+- Stay within Discord embed limits (title: 256 chars, description: 4096 chars, total embed: 6000 chars).
+- Redaction rules: never include account ID, credentials, or internal API URLs in messages.
+- Rate limiting: respect Discord's 5 req/2s per webhook (already handled in P0 client — verify).
+- Template system: use Go templates or a formatter interface so message layout is configurable without code changes.
+
+### Portfolio API — time-series endpoints
+
+Extend the portfolio API (SCH-18) with new endpoints for chart data:
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/portfolio/history` | Session | Portfolio value over time |
+| `GET` | `/api/portfolio/positions/:symbol/history` | Session | Per-position price/value history |
+| `GET` | `/api/portfolio/metrics` | Session | Computed performance metrics |
+
+**History endpoint** query params:
+
+- `interval`: `1h`, `1d`, `1w`, `1m` (aggregation interval)
+- `from`, `to`: ISO-8601 timestamps (default: last 30 days)
+
+**Response shape** (`/api/portfolio/history`):
+
+```json
+{
+  "series": [
+    { "timestamp": "2026-04-15T15:30:00Z", "netLiquidation": 125000.00, "totalCash": 25000.00 },
+    { "timestamp": "2026-04-15T15:20:00Z", "netLiquidation": 124800.00, "totalCash": 25000.00 }
+  ],
+  "interval": "1h",
+  "from": "2026-03-15T00:00:00Z",
+  "to": "2026-04-15T23:59:59Z"
+}
+```
+
+**Metrics endpoint** response:
+
+```json
+{
+  "periodReturns": {
+    "day": 0.015,
+    "week": -0.023,
+    "month": 0.045,
+    "ytd": 0.12
+  },
+  "drawdown": {
+    "current": -0.032,
+    "max": -0.085,
+    "maxDate": "2026-03-10T00:00:00Z"
+  },
+  "asOf": "2026-04-15T15:30:00Z"
+}
+```
+
+### Persistence — time-series queries
+
+Add repository methods to query snapshot history (extends SCH-18's repository):
+
+```go
+type PortfolioHistory interface {
+    // GetValueSeries returns aggregated portfolio values over time.
+    GetValueSeries(ctx context.Context, from, to time.Time, interval string) ([]ValuePoint, error)
+
+    // GetPositionHistory returns price/value history for a symbol.
+    GetPositionHistory(ctx context.Context, symbol string, from, to time.Time) ([]PositionPoint, error)
+
+    // GetMetrics computes performance metrics from stored snapshots.
+    GetMetrics(ctx context.Context) (*PerformanceMetrics, error)
+}
+```
+
+Query against the existing `snapshots` table from P0. Add indexes if needed for time-range queries.
+
+### Dashboard — charts & metrics (`apps/web/`)
+
+Extend the P0 dashboard with new pages/components:
+
+**Charting library**: Use [Recharts](https://recharts.org/) or [Lightweight Charts](https://tradingview.github.io/lightweight-charts/) — pick one based on bundle size and feature needs. Document the choice.
+
+**New components**:
+
+- **Portfolio value chart** (`/` or `/dashboard`): line chart of net liquidation over time.
+  - Time range selector: 1D, 1W, 1M, 3M, YTD, ALL.
+  - Tooltip with exact values on hover.
+- **Position detail view** (`/positions/:symbol`): per-position chart + stats.
+  - Price history line chart.
+  - Position stats card (entry, current, P&L, weight).
+- **Metrics dashboard** (`/metrics` or sidebar widget):
+  - Period returns (day, week, month, YTD).
+  - Current drawdown + max drawdown.
+  - Color-coded (green/red) like the P0 positions table.
+
+**Layout updates**:
+
+- Add navigation: Dashboard (positions table) | Charts | Metrics.
+- Responsive: charts should resize properly; use aspect-ratio containers.
+
+### Caching
+
+- Time-series queries can be expensive. Add a simple in-memory or Redis cache for computed metrics (TTL: 1 minute during market hours, 10 minutes outside).
+- Cache key: `metrics:{interval}:{from}:{to}` or similar.
+
+## Do NOT
+
+- Implement auto-trading or order placement (P2, SCH-24).
+- Replace or modify P0's deterministic signal rules (SCH-16 owns those).
+- Add benchmark overlays (parked — can revisit later).
+- Build a mobile native app.
+- Implement real-time websocket streaming (polling is acceptable for P1).
+
+## Acceptance criteria
+
+- [ ] Discord alert with rich embed fires on a replayed/fixture signal event.
+- [ ] Rich alert includes rationale, levels, portfolio context, and links.
+- [ ] Message respects Discord embed size limits (verified with long text).
+- [ ] Secrets/internal URLs are redacted from Discord messages.
+- [ ] `/api/portfolio/history` returns time-series data with interval aggregation.
+- [ ] `/api/portfolio/positions/:symbol/history` returns per-position data.
+- [ ] `/api/portfolio/metrics` returns computed period returns and drawdown.
+- [ ] Dashboard shows portfolio value chart with time range selector.
+- [ ] Dashboard shows at least one multi-interval performance view.
+- [ ] Dashboard navigation updated with Charts/Metrics sections.
+- [ ] Documented limits: Discord message size, chart data cardinality.
+- [ ] Charting library choice documented in README or ADR.
+
+## Shared contracts
+
+This epic **consumes**:
+
+- **SCH-16** `SignalEvent` type — the base event enriched into `RichAlert`.
+- **SCH-16** Discord client — extended with embed support.
+- **SCH-18** `snapshots` table — queried for time-series data.
+- **SCH-18** Portfolio API — extended with new endpoints.
+- **SCH-17** Dashboard stylekit — charts use the same theme tokens.
+- **SCH-21** Snapshot retention — depends on accumulated history.
+
+This epic **produces**:
+
+- Rich Discord embeds — end-user notifications (replaces P0 minimal format).
+- Time-series API endpoints — consumed by the dashboard.
+- `RichAlert` type — may be consumed by SCH-23 (OpenClaw) for context.
+
+## Files to create/modify
+
+| File | Action |
+|------|--------|
+| `internal/discord/rich.go` | Create (rich alert formatter) |
+| `internal/discord/rich_test.go` | Create (embed size validation) |
+| `internal/discord/templates/` | Create (message templates) |
+| `internal/portfolio/history.go` | Create (time-series repository interface) |
+| `internal/portfolio/postgres/history.go` | Create (time-series queries) |
+| `internal/portfolio/metrics.go` | Create (metrics computation) |
+| `internal/portfolio/metrics_test.go` | Create (with fixture snapshots) |
+| `cmd/portfolio-api/main.go` | Modify (register new routes) |
+| `apps/web/app/dashboard/page.tsx` | Create or modify (chart view) |
+| `apps/web/app/positions/[symbol]/page.tsx` | Create (position detail) |
+| `apps/web/app/metrics/page.tsx` | Create (metrics view) |
+| `apps/web/components/portfolio-chart.tsx` | Create |
+| `apps/web/components/position-chart.tsx` | Create |
+| `apps/web/components/metrics-cards.tsx` | Create |
+| `apps/web/components/time-range-selector.tsx` | Create |
+| `apps/web/components/nav.tsx` | Modify (add navigation items) |

--- a/.agent/epics/SCH-23-openclaw-mcp-alerts.md
+++ b/.agent/epics/SCH-23-openclaw-mcp-alerts.md
@@ -1,0 +1,216 @@
+# SCH-23: OpenClaw, MCP & Alert Intelligence
+
+> **Linear**: [SCH-23](https://linear.app/schtvr/issue/SCH-23/epic-p1-openclaw-mcp-and-alert-intelligence)
+> **Milestone**: P1: First follow-up
+> **Wave**: 5 (all P0 complete; parallel with SCH-22)
+> **Depends on**: P0 complete — specifically SCH-16 (SignalEvent), SCH-18 (portfolio API), SCH-21 (snapshots)
+
+## Objective
+
+Route structured `SignalEvent` traffic into OpenClaw with relevant MCP tools (portfolio snapshot, fundamentals/news), hardening the alert proxy path. Default to human-in-the-loop — no broker orders from this epic.
+
+## Scope
+
+### Architecture overview
+
+```
+Signal Engine (P0)          OpenClaw Proxy           OpenClaw
+┌──────────┐    SignalEvent   ┌──────────────┐        ┌──────────┐
+│ SCH-16   │ ──────────────► │  SCH-23      │ ────►  │ OpenClaw │
+│ signals  │                 │  proxy svc   │ ◄────  │ agent    │
+└──────────┘                 │              │        │          │
+                             │  MCP servers │        │ MCP      │
+                             │  ┌─────────┐ │        │ client   │
+                             │  │portfolio│ │ ◄──────│          │
+                             │  │snapshot │ │        └──────────┘
+                             │  ├─────────┤ │
+                             │  │news/    │ │
+                             │  │fundmtls │ │
+                             │  └─────────┘ │
+                             └──────────────┘
+                                    │
+                                    ▼
+                             Human approval
+                             (Discord / dashboard)
+```
+
+### OpenClaw proxy service (`cmd/openclaw-proxy/`)
+
+A new Go service that:
+
+1. **Receives** `SignalEvent` payloads from the signal engine.
+2. **Enriches** with portfolio context (positions, account summary) via the portfolio API.
+3. **Forwards** to OpenClaw with MCP tool definitions attached.
+4. **Receives** the agent's analysis/recommendation.
+5. **Routes** the recommendation to the human-in-the-loop channel (Discord rich alert via SCH-22, or a dashboard notification).
+
+**Delivery mechanism** — pick one and document:
+
+- **Option A**: HTTP endpoint that the signal engine calls directly (synchronous, simpler).
+- **Option B**: Message queue (Redis pub/sub, NATS, or a simple Go channel-based async boundary) so the signal pipeline is never blocked by OpenClaw latency.
+
+Recommendation: **Option B** (async) for resilience. If OpenClaw is slow or down, the signal pipeline keeps running. Implement with a simple in-process queue for P1; can swap to external queue later.
+
+### Integration contract
+
+**Request to OpenClaw**:
+
+```go
+type OpenClawRequest struct {
+    RequestID     string            `json:"requestId"`     // idempotency key (UUID)
+    Signal        signal.SignalEvent `json:"signal"`
+    PortfolioCtx  PortfolioContext   `json:"portfolioCtx"`
+    MCPTools      []string           `json:"mcpTools"`      // tool names available
+    CreatedAt     time.Time          `json:"createdAt"`
+}
+
+type PortfolioContext struct {
+    Positions      []broker.Position      `json:"positions"`
+    AccountSummary *broker.AccountSummary `json:"accountSummary"`
+    SnapshotAt     time.Time              `json:"snapshotAt"`
+}
+```
+
+**Response from OpenClaw**:
+
+```go
+type OpenClawResponse struct {
+    RequestID     string    `json:"requestId"`
+    Analysis      string    `json:"analysis"`      // agent's reasoning
+    Recommendation string  `json:"recommendation"` // action suggestion
+    Confidence    float64   `json:"confidence"`     // 0.0–1.0
+    ToolCalls     []ToolCall `json:"toolCalls"`     // MCP tools the agent used
+    CompletedAt   time.Time  `json:"completedAt"`
+}
+
+type ToolCall struct {
+    Tool     string          `json:"tool"`
+    Input    json.RawMessage `json:"input"`
+    Output   json.RawMessage `json:"output"`
+    Duration time.Duration   `json:"duration"`
+}
+```
+
+**Timeouts & retries**:
+
+- Request timeout: 30 seconds (configurable).
+- Retry: 1 retry with exponential backoff on transient errors (5xx, timeout).
+- Circuit breaker: after 3 consecutive failures, stop forwarding for 5 minutes (log warnings).
+
+### MCP servers
+
+Implement MCP tool servers that OpenClaw's agent can call:
+
+#### Portfolio snapshot MCP (`internal/mcp/portfolio/`)
+
+Exposes portfolio data as MCP tools:
+
+| Tool | Description | Input | Output |
+|------|-------------|-------|--------|
+| `get_positions` | Current portfolio positions | `{}` | `{ positions: [...] }` |
+| `get_account_summary` | Account-level metrics | `{}` | `{ summary: {...} }` |
+| `get_position_detail` | Detail for a specific symbol | `{ symbol: "AAPL" }` | `{ position: {...}, history: [...] }` |
+
+Implementation: thin HTTP wrapper around the portfolio API (SCH-18).
+
+#### News/fundamentals MCP (`internal/mcp/market/`)
+
+Stub for P1 — document the interface, implement with mock data or a simple external API:
+
+| Tool | Description | Input | Output |
+|------|-------------|-------|--------|
+| `get_news` | Recent news for a symbol | `{ symbol: "AAPL", limit: 5 }` | `{ articles: [...] }` |
+| `get_fundamentals` | Basic fundamentals | `{ symbol: "AAPL" }` | `{ pe: 28.5, marketCap: "2.8T", ... }` |
+
+Implementation options for P1:
+- Mock data (sufficient for testing the pipeline).
+- Free API integration (Alpha Vantage, Finnhub — document choice if real).
+
+### Human-in-the-loop
+
+- **Default mode**: all OpenClaw recommendations are for human review only.
+- Route agent output to Discord (using SCH-22's rich alert format) or a dashboard notification endpoint.
+- No automated order placement — that's P2 (SCH-24).
+- Log the full request/response cycle for audit.
+
+### Observability
+
+- Structured logs for every OpenClaw invocation: request ID, signal ID, duration, tool calls made, success/failure.
+- Redact secrets (API keys, account IDs) from logs.
+- Metrics (if instrumented): invocation count, latency p50/p99, error rate, tool call frequency.
+
+### Configuration
+
+```env
+OPENCLAW_API_URL=http://openclaw:8090
+OPENCLAW_API_KEY=changeme
+OPENCLAW_TIMEOUT=30s
+OPENCLAW_RETRY_MAX=1
+OPENCLAW_CIRCUIT_BREAKER_THRESHOLD=3
+OPENCLAW_CIRCUIT_BREAKER_RESET=5m
+PORTFOLIO_API_URL=http://portfolio-api:8080
+INTERNAL_API_KEY=changeme
+```
+
+### Compose wiring
+
+Add to `docker-compose.yml`:
+
+| Service | Image / Build | Ports | Notes |
+|---------|---------------|-------|-------|
+| `openclaw-proxy` | `./` (target cmd) | `8090:8090` | Proxy service |
+
+Depends on: `portfolio-api`, `signals`.
+
+## Do NOT
+
+- Implement auto-trade execution or order placement (P2, SCH-24).
+- Replace or modify P0's deterministic signal rules (SCH-16 owns those).
+- Build a full ML/LLM signal pipeline — OpenClaw is the agent runtime.
+- Expose MCP servers to the public internet.
+
+## Acceptance criteria
+
+- [ ] A synthetic/replayed `SignalEvent` triggers an OpenClaw run with MCP tools attached.
+- [ ] Logs prove MCP tool calls occurred (portfolio snapshot retrieved by agent).
+- [ ] OpenClaw failures do not block or wedge the signal pipeline.
+- [ ] Circuit breaker activates after consecutive failures; resumes after reset period.
+- [ ] Idempotency: duplicate request IDs are handled gracefully.
+- [ ] Human-in-the-loop: agent recommendations routed to Discord or dashboard, not to broker.
+- [ ] All secrets redacted from logs.
+- [ ] Decision doc: async vs sync delivery mechanism.
+
+## Shared contracts
+
+This epic **consumes**:
+
+- **SCH-16** `SignalEvent` — the trigger for OpenClaw runs.
+- **SCH-18** Portfolio API — fetches positions/summary for context + MCP tools.
+- **SCH-20** Broker domain types — used in `PortfolioContext`.
+- **SCH-22** Rich Discord alerts — routes recommendations to human.
+
+This epic **produces**:
+
+- `OpenClawRequest` / `OpenClawResponse` — the integration contract with OpenClaw.
+- MCP tool servers — consumed by OpenClaw's agent.
+- Audit logs of agent invocations.
+- Foundation for P2 auto-trade (SCH-24 will extend recommendation routing to order placement).
+
+## Files to create/modify
+
+| File | Action |
+|------|--------|
+| `cmd/openclaw-proxy/main.go` | Create |
+| `internal/openclaw/client.go` | Create (OpenClaw HTTP client) |
+| `internal/openclaw/client_test.go` | Create |
+| `internal/openclaw/types.go` | Create (request/response types) |
+| `internal/openclaw/proxy.go` | Create (orchestration: enrich → forward → route) |
+| `internal/openclaw/proxy_test.go` | Create |
+| `internal/openclaw/circuit.go` | Create (circuit breaker) |
+| `internal/openclaw/queue.go` | Create (async boundary) |
+| `internal/mcp/portfolio/server.go` | Create (MCP tool server) |
+| `internal/mcp/portfolio/server_test.go` | Create |
+| `internal/mcp/market/server.go` | Create (stub/mock) |
+| `internal/mcp/market/server_test.go` | Create |
+| `docker-compose.yml` | Modify (add openclaw-proxy service) |
+| `.env.example` | Modify (add OPENCLAW_* vars) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,25 +23,32 @@ morgans-d-stonks/
 ├── .github/workflows/ci.yml
 ├── .agent/
 │   └── epics/                   # agent instruction files (one per epic)
-│       ├── SCH-19-foundation-homelab.md
-│       ├── SCH-20-ibkr-connectivity.md
-│       ├── SCH-18-portfolio-service.md
-│       ├── SCH-17-dashboard.md
-│       ├── SCH-21-ingest-snapshots.md
-│       └── SCH-16-signals-discord.md
+│       ├── SCH-19-foundation-homelab.md       # P0 Wave 1
+│       ├── SCH-20-ibkr-connectivity.md        # P0 Wave 2
+│       ├── SCH-18-portfolio-service.md        # P0 Wave 2
+│       ├── SCH-17-dashboard.md                # P0 Wave 2–3
+│       ├── SCH-21-ingest-snapshots.md         # P0 Wave 3
+│       ├── SCH-16-signals-discord.md          # P0 Wave 4
+│       ├── SCH-22-rich-alerts-dashboard-analytics.md  # P1 Wave 5
+│       └── SCH-23-openclaw-mcp-alerts.md      # P1 Wave 5
 ├── apps/
 │   └── web/                     # Next.js dashboard
 ├── cmd/
 │   ├── portfolio-api/           # Go HTTP service
 │   ├── ingest/                  # Go periodic job
-│   └── signals/                 # Go signal engine
+│   ├── signals/                 # Go signal engine
+│   └── openclaw-proxy/          # Go OpenClaw proxy (P1)
 ├── internal/
 │   ├── broker/                  # Broker interface + IBKR/mock impls
-│   ├── portfolio/               # Portfolio domain + persistence
+│   ├── portfolio/               # Portfolio domain + persistence + history
 │   ├── auth/                    # Auth logic + middleware
 │   ├── ingest/                  # Ingest runner logic
 │   ├── signal/                  # Signal engine + rules
-│   ├── discord/                 # Discord webhook client
+│   ├── discord/                 # Discord webhook + rich alerts
+│   ├── openclaw/                # OpenClaw client + proxy (P1)
+│   ├── mcp/                     # MCP tool servers (P1)
+│   │   ├── portfolio/           # Portfolio snapshot MCP
+│   │   └── market/              # News/fundamentals MCP (stub)
 │   └── config/                  # Shared config
 ├── config/
 │   └── signals.yaml             # Signal rule definitions
@@ -50,7 +57,7 @@ morgans-d-stonks/
 
 ## Agent instructions
 
-Each P0 epic has a detailed agent instruction file in `.agent/epics/`. These files contain everything an agent needs: objective, scope, interface contracts, file lists, acceptance criteria, and explicit boundaries to avoid duplication.
+Each P0 and P1 epic has a detailed agent instruction file in `.agent/epics/`. These files contain everything an agent needs: objective, scope, interface contracts, file lists, acceptance criteria, and explicit boundaries to avoid duplication.
 
 ### How to use the instruction files
 
@@ -87,6 +94,15 @@ Wave 4 ────────────────────────�
 │  SCH-16: Signals & Discord
 │  (rule engine, dedup, webhook)
 │
+═══════════════════ P0 complete ═════════════════════════════
+
+Wave 5 ──────────────────────────────────────────────────────
+│         (both can run in parallel)
+│
+│  SCH-22: Rich Alerts &           SCH-23: OpenClaw, MCP &
+│  Dashboard Analytics             Alert Intelligence
+│  (rich Discord, charts, metrics) (proxy svc, MCP servers, circuit breaker)
+│
 ```
 
 ### Parallelism rules
@@ -94,6 +110,7 @@ Wave 4 ────────────────────────�
 - **Same wave**: agents can work simultaneously without conflicts.
 - **Cross-wave**: later waves depend on interfaces/contracts from earlier waves. If an earlier wave hasn't merged yet, code against the documented interface contracts in the instruction files — they are the source of truth.
 - **SCH-17 (Dashboard)** spans two waves: the stylekit/shell work (Wave 2) has no backend dependency, but data integration (Wave 3) needs SCH-18's API.
+- **P1 epics (Wave 5)**: require all P0 epics to be merged. SCH-22 and SCH-23 can run in parallel — SCH-22 extends the Discord client and dashboard, while SCH-23 builds the OpenClaw proxy. They share the `SignalEvent` type (P0 contract) but don't modify each other's files.
 
 ## Shared contracts
 
@@ -128,7 +145,7 @@ Owner: **SCH-18** | Consumers: SCH-17, SCH-21
 
 ### SignalEvent type
 
-Owner: **SCH-16** | Future consumer: SCH-23 (P1)
+Owner: **SCH-16** | Consumers: SCH-22 (P1 rich alerts), SCH-23 (P1 OpenClaw)
 
 ```go
 type SignalEvent struct {
@@ -142,6 +159,51 @@ type SignalEvent struct {
     FiredAt   time.Time `json:"firedAt"`
 }
 ```
+
+### Portfolio API — P1 time-series endpoints
+
+Owner: **SCH-22** (extends SCH-18) | Consumers: SCH-22 dashboard charts
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/portfolio/history` | Session | Portfolio value over time (`interval`, `from`, `to` params) |
+| `GET` | `/api/portfolio/positions/:symbol/history` | Session | Per-position price/value history |
+| `GET` | `/api/portfolio/metrics` | Session | Computed period returns + drawdown |
+
+### OpenClaw integration contract
+
+Owner: **SCH-23** | Future consumer: SCH-24 (P2 auto-trade)
+
+```go
+type OpenClawRequest struct {
+    RequestID     string            `json:"requestId"`
+    Signal        signal.SignalEvent `json:"signal"`
+    PortfolioCtx  PortfolioContext   `json:"portfolioCtx"`
+    MCPTools      []string           `json:"mcpTools"`
+    CreatedAt     time.Time          `json:"createdAt"`
+}
+
+type OpenClawResponse struct {
+    RequestID      string    `json:"requestId"`
+    Analysis       string    `json:"analysis"`
+    Recommendation string    `json:"recommendation"`
+    Confidence     float64   `json:"confidence"`
+    ToolCalls      []ToolCall `json:"toolCalls"`
+    CompletedAt    time.Time  `json:"completedAt"`
+}
+```
+
+### MCP tool servers
+
+Owner: **SCH-23** | Consumer: OpenClaw agent
+
+| Tool | Server | Description |
+|------|--------|-------------|
+| `get_positions` | `mcp/portfolio` | Current portfolio positions |
+| `get_account_summary` | `mcp/portfolio` | Account-level metrics |
+| `get_position_detail` | `mcp/portfolio` | Detail for a specific symbol |
+| `get_news` | `mcp/market` | Recent news for a symbol (stub for P1) |
+| `get_fundamentals` | `mcp/market` | Basic fundamentals (stub for P1) |
 
 ### Environment variables
 
@@ -160,6 +222,9 @@ All env vars documented in `.env.example`. Each service reads only what it needs
 | `SIGNAL_RULES_PATH` | signals | SCH-16 |
 | `SIGNAL_COOLDOWN` | signals | SCH-16 |
 | `NEXT_PUBLIC_API_URL` | web | SCH-17 |
+| `OPENCLAW_API_URL` | openclaw-proxy | SCH-23 |
+| `OPENCLAW_API_KEY` | openclaw-proxy | SCH-23 |
+| `OPENCLAW_TIMEOUT` | openclaw-proxy | SCH-23 |
 
 ### Docker Compose service names
 
@@ -173,6 +238,7 @@ Owner: **SCH-19** | Used by all epics for inter-service networking.
 | `signals` | `signals` | — |
 | `db` | `db` | 5432 |
 | `ib-gateway` | `ib-gateway` | 4001 |
+| `openclaw-proxy` | `openclaw-proxy` | 8090 |
 
 ## Coding standards
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds agent instruction files for both P1 epics from the [Portfolio Platform](https://linear.app/schtvr/project/portfolio-platform-1e44112535d4) Linear project and updates `AGENTS.md` with P1 wave, shared contracts, and infrastructure.

Follows up on PR #1 which added the P0 epic instructions.

## What's included

### New instruction files

| File | Epic | Wave | Description |
|------|------|------|-------------|
| `SCH-22-rich-alerts-dashboard-analytics.md` | Rich Alerts & Dashboard Analytics | 5 | Rich Discord embeds, time-series API, charts, metrics |
| `SCH-23-openclaw-mcp-alerts.md` | OpenClaw, MCP & Alert Intelligence | 5 | OpenClaw proxy service, MCP tool servers, circuit breaker |

Both P1 epics are in **Wave 5** and can run **in parallel** after all P0 epics are complete.

### SCH-22 covers
- Discord rich embed format (rationale, levels, portfolio context, links) with embed size limits
- Time-series API endpoints (`/api/portfolio/history`, `/positions/:symbol/history`, `/metrics`)
- `PortfolioHistory` repository interface for time-range queries
- Dashboard charting (Recharts or Lightweight Charts) with time range selector
- Metrics computation (period returns, drawdown)
- Caching strategy for time-series queries

### SCH-23 covers
- OpenClaw proxy service architecture with async boundary
- `OpenClawRequest`/`OpenClawResponse` integration contract
- Circuit breaker (3 failures → 5 min cooldown)
- MCP tool servers: portfolio snapshot (real) + news/fundamentals (stub)
- Human-in-the-loop routing (recommendations to Discord, not broker)
- Observability (structured logs, secret redaction)

### AGENTS.md updates
- Wave 5 added to execution diagram with P0/P1 boundary marker
- Repo layout updated: `cmd/openclaw-proxy/`, `internal/openclaw/`, `internal/mcp/`
- New shared contracts: P1 time-series API, OpenClaw contract, MCP tool table
- Env vars: `OPENCLAW_API_URL`, `OPENCLAW_API_KEY`, `OPENCLAW_TIMEOUT`
- Compose services: `openclaw-proxy` on port 8090
- Parallelism rules updated for P1 wave
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eabdc49f-afbd-4786-9edd-49ec51bbadd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eabdc49f-afbd-4786-9edd-49ec51bbadd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

