### PR TITLE
Add P1 logging epic, agent skill, and AGENTS updates

### DIFF
--- a/.agent/epics/phase_1/logging/epic_P1_logging.md
+++ b/.agent/epics/phase_1/logging/epic_P1_logging.md
@@ -1,0 +1,91 @@
+# P1: Structured logging for Loki / homelab observability
+
+> **Linear**: _(create issue and link — e.g. SCH-XX)_  
+> **Milestone**: P1: Follow-up (cross-cutting; implement after core P0 paths exist)  
+> **Wave**: After P0 MVP services are stable; can ship in parallel with Phase 2 epics where touch points are isolated.  
+> **Depends on**: SCH-19 (layout), SCH-18 (`portfolio-api`), SCH-21 (`ingest`), SCH-16 (`signals`) — for meaningful access and tick logs.
+
+## Objective
+
+Make every Go service emit **consistent, JSON structured logs** on stdout suitable for **Grafana Loki + Promtail** (and any log shipper): stable field names, low-cardinality labels via log attributes, request correlation on the API, worker “heartbeat” summaries, and **no secrets** in log lines.
+
+## Scope
+
+### Shared package: `internal/logging`
+
+- Provide a single constructor for the process root `*slog.Logger` (JSON handler → **stdout**).
+- **Required** static attribute: `service` — one of: `portfolio-api`, `ingest`, `signals` (and future binaries as they appear).
+- **Optional** static attribute: `version` — from build (`-ldflags`) or env `APP_VERSION` (homelab-friendly).
+- **Log level** from env `LOG_LEVEL` (values: `debug`, `info`, `warn`, `error`; default `info`). Invalid values → default + one warning line or silent fallback (document choice).
+- Package must include `_test.go` (level parsing, JSON contains `service`).
+
+### `cmd/*` entrypoints
+
+- Replace ad-hoc `slog.New(slog.NewJSONHandler(...))` with `internal/logging`.
+- Each binary passes its **distinct** `service` name.
+
+### `portfolio-api` (`cmd/portfolio-api`, HTTP stack)
+
+- **Access logging**: one structured log line per HTTP request after completion with at least: `method`, `path` (route pattern preferred over raw URL to limit cardinality; strip query string minimum), `status`, `duration_ms`, `bytes` (response size if practical).
+- **Request correlation**: include chi `RequestID` on every access log line; prefer propagating `request_id` into context for any handler-level logs (middleware or `slog` context pattern).
+- **Redaction**: never log `Authorization`, session cookie values, request bodies for auth routes, or `X-Internal-Key`. Sanitize or omit upstream error bodies that might echo secrets.
+
+### `ingest` (`internal/ingest` / `cmd/ingest`)
+
+- **Per-tick summary** at `INFO`: e.g. tick outcome, duration, position/snapshot counts or equivalent high-signal fields, market open/closed path when applicable.
+- **WARN** on retry/skip paths with stable attributes; do not log full HTTP response bodies from portfolio-api.
+
+### `signals` (`cmd/signals`)
+
+- **Per-tick summary** at `INFO`: rules loaded count, events evaluated, fires sent (or suppressed), Discord enabled flag, Discord send errors aggregated count, duration.
+- Enrich per-fire logs with `rule_id`, `symbol` where not already present; keep Discord webhook URL out of logs.
+
+### Configuration surface
+
+- Document `LOG_LEVEL` and `APP_VERSION` in **`.env.example`** (optional vars with defaults described in comments).
+
+### TypeScript / Next.js (`apps/web`)
+
+- **Out of scope** for this epic unless extended: dashboard logging remains unchanged. Promtail may still scrape container stdout for `web` using docker labels.
+
+## Do NOT
+
+- Add Prometheus metrics or OpenTelemetry tracing (separate epic if desired).
+- Add new HTTP endpoints solely for logging (keep using stdout for Loki).
+- Log secrets, API keys, webhook URLs, or raw session tokens.
+- Introduce high-cardinality fields as required labels (e.g. per-symbol streams on every access log line).
+
+## Acceptance criteria
+
+- [ ] `internal/logging` exists with tests; all Go services use it for the root logger.
+- [ ] Every log line JSON includes `service` (and `version` when `APP_VERSION` or build metadata is set).
+- [ ] `LOG_LEVEL` changes verbosity without code change (verified with at least one test or manual note in PR).
+- [ ] `portfolio-api` emits structured access logs with `request_id` and without sensitive headers/bodies.
+- [ ] `ingest` emits an `INFO` tick summary suitable for “last successful run” dashboards.
+- [ ] `signals` emits an `INFO` tick summary and does not log `DISCORD_WEBHOOK_URL` or internal key material.
+- [ ] `.env.example` documents `LOG_LEVEL` / `APP_VERSION`.
+- [ ] `go test ./...` passes.
+
+## Shared contracts
+
+- **Consumers**: homelab Grafana/Loki dashboards; future runbooks.
+- **No change** to HTTP API contracts, broker interface, or `SignalEvent` JSON shape — only observability.
+
+## Files to create/modify
+
+| File | Action |
+|------|--------|
+| `internal/logging/logger.go` | Create (constructor, level parsing, attrs) |
+| `internal/logging/logger_test.go` | Create |
+| `cmd/portfolio-api/main.go` | Modify (logger + access middleware) |
+| `cmd/ingest/main.go` | Modify (logger) |
+| `cmd/signals/main.go` | Modify (logger + tick summary fields) |
+| `internal/ingest/runner.go` (and related) | Modify (tick summary logs) |
+| `.env.example` | Modify (`LOG_LEVEL`, `APP_VERSION`) |
+| `AGENTS.md` | Modify (layout, env table, skills pointer) |
+| `.agent/skills/logging.md` | Create (agent quick reference) |
+
+## Agent execution notes
+
+- Read `.agent/skills/logging.md` for field naming and redaction checklist before editing handlers.
+- One logical PR is fine; if splitting, land `internal/logging` + `cmd/*` wiring first, then API middleware, then worker summaries.

--- a/.agent/skills/logging.md
+++ b/.agent/skills/logging.md
@@ -1,0 +1,39 @@
+# Skill: Structured logging (`internal/logging`)
+
+Use this when adding or changing logs in Go services for this repo.
+
+## Where logging lives
+
+- **Root logger**: built once in each `cmd/<binary>/main.go` via `internal/logging` — do not create duplicate `slog.NewJSONHandler` setups in binaries.
+- **Libraries**: accept `*slog.Logger` or `slog.Handler` from the caller when non-trivial operational logs are needed; avoid global loggers.
+
+## Required conventions
+
+- **Field names**: use **snake_case** for attribute keys in structured logs (`request_id`, `duration_ms`, `rule_id`) so Loki/Grafana queries stay consistent.
+- **Service identity**: every process must emit `service` (`portfolio-api`, `ingest`, `signals`, …) on each line — handled by `internal/logging`, not repeated in call sites.
+- **Levels**: `debug` for noisy diagnostics; `info` for normal lifecycle and tick summaries; `warn` for recoverable degradation; `error` for failures that may need human attention.
+
+## Never log
+
+- Passwords, `AUTH_SECRET`, session tokens or cookie values, `X-Internal-Key`, full `DISCORD_WEBHOOK_URL`, database URLs with credentials.
+- Full HTTP request/response bodies from auth or internal routes unless explicitly sanitized and truncated.
+
+## portfolio-api
+
+- Include **`request_id`** on access logs (from chi middleware).
+- Prefer **route pattern** over raw path+query for the logged `path` where possible to avoid cardinality explosions in Loki.
+
+## Workers (ingest, signals)
+
+- Emit one **`info`** line per successful tick with **counts and duration**, not per-position spam unless `LOG_LEVEL=debug`.
+
+## Env vars
+
+| Variable | Purpose |
+|----------|---------|
+| `LOG_LEVEL` | `debug` / `info` / `warn` / `error` (default `info`) |
+| `APP_VERSION` | Optional semver or git SHA attached to every log line |
+
+## Epic source of truth
+
+Implementation scope and acceptance criteria: `.agent/epics/phase_1/logging/epic_P1_logging.md`.

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Optional: structured logging (all Go binaries — see .agent/epics/phase_1/logging/epic_P1_logging.md)
+# LOG_LEVEL=info
+# APP_VERSION=dev
+
 # Database
 POSTGRES_USER=portfolio
 POSTGRES_PASSWORD=changeme

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,17 +22,21 @@ morgans-d-stonks/
 ├── .gitignore
 ├── .github/workflows/ci.yml
 ├── .agent/
-│   └── epics/
-│       ├── phase_1/             # P0 (MVP) epics
-│       │   ├── foundation-homelab.md
-│       │   ├── ibkr-connectivity.md
-│       │   ├── portfolio-service.md
-│       │   ├── dashboard.md
-│       │   ├── ingest-snapshots.md
-│       │   └── signals-discord.md
-│       └── phase_2/             # P1 (first follow-up) epics
-│           ├── rich-alerts-dashboard-analytics.md
-│           └── openclaw-mcp-alerts.md
+│   ├── epics/
+│   │   ├── phase_1/             # P0 (MVP) epics
+│   │   │   ├── foundation-homelab.md
+│   │   │   ├── ibkr-connectivity.md
+│   │   │   ├── portfolio-service.md
+│   │   │   ├── dashboard.md
+│   │   │   ├── ingest-snapshots.md
+│   │   │   ├── signals-discord.md
+│   │   │   └── logging/         # P1 cross-cutting (stdout JSON for Loki)
+│   │   │       └── epic_P1_logging.md
+│   │   └── phase_2/             # P1 (first follow-up) epics
+│   │       ├── rich-alerts-dashboard-analytics.md
+│   │       └── openclaw-mcp-alerts.md
+│   └── skills/                  # Short agent checklists (read with assigned epic)
+│       └── logging.md
 ├── apps/
 │   └── web/                     # Next.js dashboard
 ├── cmd/
@@ -47,6 +51,7 @@ morgans-d-stonks/
 │   ├── ingest/
 │   ├── signal/
 │   ├── discord/
+│   ├── logging/                 # P1 shared slog setup (epic_P1_logging)
 │   ├── openclaw/                # P1
 │   ├── mcp/                     # P1
 │   │   ├── portfolio/
@@ -61,11 +66,15 @@ morgans-d-stonks/
 
 ### How to read the epic files
 
-1. Read the instruction file for your assigned epic under `.agent/epics/phase_1/` or `phase_2/`.
+1. Read the instruction file for your assigned epic under `.agent/epics/phase_1/` or `phase_2/` (including nested dirs such as `phase_1/logging/`).
 2. Check the **Wave** and **Depends on** fields to understand ordering.
 3. Follow **Scope** for implementation details; respect **Do NOT** to avoid conflicts.
 4. Verify every item in **Acceptance criteria** before marking done.
 5. If a **Shared contract** must change, update all listed consuming epics.
+
+### Optional skills (checklists)
+
+For structured logging work, read `.agent/skills/logging.md` alongside `.agent/epics/phase_1/logging/epic_P1_logging.md`.
 
 ### Git workflow
 
@@ -113,6 +122,7 @@ Phase 2 (P1) ──────────────────────�
 │
 │  Wave 5:  SCH-22  Rich Alerts & Analytics  (parallel)
 │           SCH-23  OpenClaw, MCP & Alerts
+│           P1 logging (stdout JSON / Loki) — see `phase_1/logging/epic_P1_logging.md`
 │
 ```
 
@@ -225,6 +235,8 @@ Owner: **SCH-23** | Consumer: OpenClaw agent
 | `OPENCLAW_API_URL` | openclaw-proxy | SCH-23 |
 | `OPENCLAW_API_KEY` | openclaw-proxy | SCH-23 |
 | `OPENCLAW_TIMEOUT` | openclaw-proxy | SCH-23 |
+| `LOG_LEVEL` | all Go services | P1 logging epic |
+| `APP_VERSION` | all Go services (optional) | P1 logging epic |
 
 ### Docker Compose service names
 
@@ -246,7 +258,7 @@ Owner: **SCH-23** | Consumer: OpenClaw agent
 - Interfaces defined by the consumer (except the shared `Broker`).
 - Error wrapping: `fmt.Errorf("context: %w", err)`.
 - Context propagation for all I/O.
-- Structured logging via `slog` (standard library) — use consistently across all services.
+- Structured logging via `slog` (standard library) — use consistently across all services; shared root logger setup lives in `internal/logging` (see `.agent/epics/phase_1/logging/epic_P1_logging.md`).
 
 ### TypeScript / Next.js
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,6 @@ morgans-d-stonks/
 │   │   │   ├── ingest-snapshots.md
 │   │   │   ├── signals-discord.md
 │   │   │   └── logging/         # P1 cross-cutting (stdout JSON for Loki)
-│   │   │       └── epic_P1_logging.md
 │   │   │       ├── epic_P1_logging.md
 │   │   │       └── stories/
 │   │   └── phase_2/             # P1 (first follow-up) epics


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds the **P1 structured logging** epic as documentation-only work: epic file, a short **agent skill** checklist, **AGENTS.md** layout and env table updates, and optional **`LOG_LEVEL` / `APP_VERSION`** comments in `.env.example`.

## Details

- **Epic**: `.agent/epics/phase_1/logging/epic_P1_logging.md` — scope for `internal/logging`, `portfolio-api` access logs, ingest/signals tick summaries, redaction rules, and acceptance criteria (implementation is follow-up).
- **Skill**: `.agent/skills/logging.md` — conventions (snake_case fields, never-log list, env vars) for agents working on that epic.
- **AGENTS.md**: repository tree now includes `phase_1/logging/`, `.agent/skills/`, and future `internal/logging/`; execution waves note P1 logging; environment table lists `LOG_LEVEL` and `APP_VERSION`; epic-reading step mentions nested epic dirs.

## Testing

- `go test ./...` (no code changes beyond docs).

Linear issue ID was not available; commit message omits `SCH-XX` — link a Linear issue when one exists for this epic.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

