### PR TITLE
P1 logging story 01: internal/logging package

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,53 @@
+// Package logging provides a shared JSON slog logger for service stdout (Loki-friendly).
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// New returns a JSON slog.Logger to stdout with attrs service, optional version,
+// and level from LOG_LEVEL (default info). Invalid LOG_LEVEL writes one line to stderr and uses info.
+func New(service string) *slog.Logger {
+	return newLogger(service, os.Getenv("LOG_LEVEL"), os.Getenv("APP_VERSION"), os.Stdout, os.Stderr)
+}
+
+func newLogger(service, logLevelEnv, appVersion string, out, errOut io.Writer) *slog.Logger {
+	if service == "" {
+		service = "unknown"
+	}
+	level, ok := parseLevel(logLevelEnv)
+	if !ok && strings.TrimSpace(logLevelEnv) != "" {
+		_, _ = fmt.Fprintf(errOut, "logging: invalid LOG_LEVEL=%q, using info\n", logLevelEnv)
+		level = slog.LevelInfo
+	}
+	opts := &slog.HandlerOptions{Level: level}
+	h := slog.NewJSONHandler(out, opts)
+	var lg *slog.Logger
+	if v := strings.TrimSpace(appVersion); v != "" {
+		lg = slog.New(h).With("service", service, "version", v)
+	} else {
+		lg = slog.New(h).With("service", service)
+	}
+	return lg
+}
+
+func parseLevel(s string) (slog.Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return slog.LevelInfo, true
+	case "debug":
+		return slog.LevelDebug, true
+	case "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error":
+		return slog.LevelError, true
+	default:
+		return slog.LevelInfo, false
+	}
+}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,104 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestParseLevel_valid(t *testing.T) {
+	tests := []struct {
+		in   string
+		want slog.Level
+	}{
+		{"", slog.LevelInfo},
+		{"  ", slog.LevelInfo},
+		{"info", slog.LevelInfo},
+		{"INFO", slog.LevelInfo},
+		{"debug", slog.LevelDebug},
+		{"warn", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"error", slog.LevelError},
+	}
+	for _, tt := range tests {
+		got, ok := parseLevel(tt.in)
+		if !ok {
+			t.Fatalf("parseLevel(%q): expected ok", tt.in)
+		}
+		if got != tt.want {
+			t.Fatalf("parseLevel(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParseLevel_invalid(t *testing.T) {
+	_, ok := parseLevel("nope")
+	if ok {
+		t.Fatal("expected invalid")
+	}
+}
+
+func TestNewLogger_JSONContainsService(t *testing.T) {
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	log := newLogger("test-service", "info", "", &out, &errBuf)
+	log.Info("hello", "k", 1)
+	if errBuf.Len() != 0 {
+		t.Fatalf("stderr: %s", errBuf.String())
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out.Bytes(), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["service"] != "test-service" {
+		t.Fatalf("service = %v", m["service"])
+	}
+	if m["msg"] != "hello" {
+		t.Fatalf("msg = %v", m["msg"])
+	}
+}
+
+func TestNewLogger_versionAttr(t *testing.T) {
+	var out bytes.Buffer
+	log := newLogger("ingest", "info", "1.2.3", &out, io.Discard)
+	log.Warn("x")
+	var m map[string]any
+	_ = json.Unmarshal(out.Bytes(), &m)
+	if m["version"] != "1.2.3" {
+		t.Fatalf("version = %v", m["version"])
+	}
+}
+
+func TestNewLogger_invalidLevelFallbackAndStderr(t *testing.T) {
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	log := newLogger("svc", "bogus", "", &out, &errBuf)
+	if !strings.Contains(errBuf.String(), "invalid LOG_LEVEL") {
+		t.Fatalf("expected stderr warning, got %q", errBuf.String())
+	}
+	// Fallback info: debug should not appear
+	if log.Enabled(nil, slog.LevelDebug) {
+		t.Fatal("expected info level")
+	}
+	log.Info("ok")
+	var m map[string]any
+	_ = json.Unmarshal(out.Bytes(), &m)
+	if m["msg"] != "ok" {
+		t.Fatalf("msg = %v", m["msg"])
+	}
+}
+
+func TestNewLogger_debugLevel(t *testing.T) {
+	var out bytes.Buffer
+	log := newLogger("svc", "debug", "", &out, io.Discard)
+	if !log.Enabled(nil, slog.LevelDebug) {
+		t.Fatal("expected debug enabled")
+	}
+	log.Debug("trace")
+	if !bytes.Contains(out.Bytes(), []byte(`"msg":"trace"`)) {
+		t.Fatalf("output: %s", out.String())
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [.agent/epics/phase_1/logging/stories/story-01-internal-logging-package.md](.agent/epics/phase_1/logging/stories/story-01-internal-logging-package.md).

- JSON slog to stdout with `service` and optional `version` from `APP_VERSION`
- `LOG_LEVEL` parsing with stderr warning on invalid values
- Tests for parsing, JSON shape, and fallback behavior
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

