### PR TITLE
P1 logging story 02: wire cmd binaries to internal/logging

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -2,17 +2,17 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"time"
 
 	"github.com/schtvr/morgans-d-stonks/internal/broker"
 	"github.com/schtvr/morgans-d-stonks/internal/brokerwire"
 	"github.com/schtvr/morgans-d-stonks/internal/ingest"
+	"github.com/schtvr/morgans-d-stonks/internal/logging"
 )
 
 func main() {
-	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	log := logging.New("ingest")
 
 	cfg := broker.LoadConfigFromEnv()
 	br, err := brokerwire.New(cfg)

--- a/cmd/portfolio-api/main.go
+++ b/cmd/portfolio-api/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/schtvr/morgans-d-stonks/internal/auth"
 	"github.com/schtvr/morgans-d-stonks/internal/config"
+	"github.com/schtvr/morgans-d-stonks/internal/logging"
 	"github.com/schtvr/morgans-d-stonks/internal/portfolio"
 	pgstore "github.com/schtvr/morgans-d-stonks/internal/portfolio/postgres"
 )
@@ -26,7 +27,7 @@ import (
 // REST API for portfolio snapshots and single-user session auth (SCH-18).
 func main() {
 	cfg := config.LoadPortfolioAPI()
-	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	log := logging.New("portfolio-api")
 
 	if cfg.DatabaseURL == "" {
 		log.Error("DATABASE_URL is required")

--- a/cmd/signals/main.go
+++ b/cmd/signals/main.go
@@ -14,12 +14,13 @@ import (
 
 	"github.com/schtvr/morgans-d-stonks/internal/config"
 	"github.com/schtvr/morgans-d-stonks/internal/discord"
+	"github.com/schtvr/morgans-d-stonks/internal/logging"
 	"github.com/schtvr/morgans-d-stonks/internal/portfolio"
 	sigpkg "github.com/schtvr/morgans-d-stonks/internal/signal"
 )
 
 func main() {
-	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	log := logging.New("signals")
 
 	cfg := config.LoadSignals()
 

--- a/internal/ingest/runner.go
+++ b/internal/ingest/runner.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/schtvr/morgans-d-stonks/internal/broker"
+	"github.com/schtvr/morgans-d-stonks/internal/logging"
 )
 
 // Runner orchestrates periodic snapshot ingestion.
@@ -22,7 +23,7 @@ type Runner struct {
 // Run blocks until SIGINT/SIGTERM, executing ticks on Interval.
 func (r *Runner) Run(ctx context.Context) error {
 	if r.Log == nil {
-		r.Log = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+		r.Log = logging.New("ingest")
 	}
 	t := time.NewTicker(r.Interval)
 	defer t.Stop()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [.agent/epics/phase_1/logging/stories/story-02-wire-cmd-loggers.md](.agent/epics/phase_1/logging/stories/story-02-wire-cmd-loggers.md).

- `portfolio-api`, `ingest`, `signals` use `logging.New` with distinct `service` values
- Ingest `Runner` nil fallback uses `logging.New("ingest")`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

