### PR TITLE
P1 logging story 03: portfolio-api access logs

### DIFF
--- a/cmd/portfolio-api/main.go
+++ b/cmd/portfolio-api/main.go
@@ -53,6 +53,7 @@ func main() {
 	r.Use(chimiddleware.RequestID)
 	r.Use(chimiddleware.RealIP)
 	r.Use(chimiddleware.Recoverer)
+	r.Use(logging.AccessLog(log))
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   cfg.CORSAllowedOrigins,
 		AllowedMethods:   []string{"GET", "POST", "OPTIONS"},

--- a/internal/logging/access.go
+++ b/internal/logging/access.go
@@ -1,0 +1,46 @@
+package logging
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+)
+
+// AccessLog returns chi middleware that emits one JSON log line per request after completion.
+// Fields: msg=http_request, method, path (route pattern when available), status, duration_ms, bytes, request_id.
+func AccessLog(log *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			ww := chimiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			next.ServeHTTP(ww, r)
+
+			path := requestPath(r)
+			log.Info("http_request",
+				"method", r.Method,
+				"path", path,
+				"status", ww.Status(),
+				"duration_ms", time.Since(start).Milliseconds(),
+				"bytes", ww.BytesWritten(),
+				"request_id", chimiddleware.GetReqID(r.Context()),
+			)
+		})
+	}
+}
+
+func requestPath(r *http.Request) string {
+	if rc := chi.RouteContext(r.Context()); rc != nil {
+		if p := rc.RoutePattern(); p != "" {
+			return p
+		}
+	}
+	p := r.URL.Path
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		return p[:i]
+	}
+	return p
+}

--- a/internal/logging/access_test.go
+++ b/internal/logging/access_test.go
@@ -1,0 +1,52 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+)
+
+func TestAccessLog_emitsJSONWithRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	r := chi.NewRouter()
+	r.Use(chimiddleware.RequestID)
+	r.Use(AccessLog(log))
+	r.Get("/api/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"status":"ok"}`)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["msg"] != "http_request" {
+		t.Fatalf("msg = %v", m["msg"])
+	}
+	if m["method"] != "GET" {
+		t.Fatalf("method = %v", m["method"])
+	}
+	if m["path"] != "/api/health" {
+		t.Fatalf("path = %v", m["path"])
+	}
+	if m["status"] != float64(200) { // json numbers
+		t.Fatalf("status = %v", m["status"])
+	}
+	rid, _ := m["request_id"].(string)
+	if rid == "" {
+		t.Fatal("expected request_id")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [.agent/epics/phase_1/logging/stories/story-03-portfolio-api-access-logs.md](.agent/epics/phase_1/logging/stories/story-03-portfolio-api-access-logs.md).

- `internal/logging.AccessLog` chi middleware: one JSON line per request with `method`, `path` (route pattern), `status`, `duration_ms`, `bytes`, `request_id`
- Wired in `cmd/portfolio-api` after `RequestID`
- `access_test.go` httptest coverage for `/api/health`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

