### PR TITLE
P1 logging story 04: ingest tick summary

### DIFF
--- a/internal/ingest/runner.go
+++ b/internal/ingest/runner.go
@@ -47,23 +47,44 @@ func (r *Runner) Run(ctx context.Context) error {
 
 func (r *Runner) tick(ctx context.Context, now time.Time) {
 	_ = now
+	start := time.Now()
+	outcome := "unknown"
+	positionCount := 0
+	var takenAt time.Time
+
+	defer func() {
+		attrs := []any{
+			"tick_outcome", outcome,
+			"duration_ms", time.Since(start).Milliseconds(),
+			"position_count", positionCount,
+		}
+		if !takenAt.IsZero() {
+			attrs = append(attrs, "taken_at", takenAt.UTC())
+		}
+		r.Log.Info("ingest_tick", attrs...)
+	}()
+
 	open, err := r.Broker.IsMarketOpen(ctx)
 	if err != nil {
+		outcome = "skipped_broker_market_check"
 		r.Log.Warn("broker market check", "err", err)
 		return
 	}
 	if !open {
-		r.Log.Info("market closed; skipping tick")
+		outcome = "skipped_market_closed"
 		return
 	}
 
 	positions, err := r.Broker.Positions(ctx)
 	if err != nil {
+		outcome = "skipped_broker_positions"
 		r.Log.Warn("broker positions", "err", err)
 		return
 	}
+	positionCount = len(positions)
 	summary, err := r.Broker.AccountSummary(ctx)
 	if err != nil {
+		outcome = "skipped_broker_summary"
 		r.Log.Warn("broker summary", "err", err)
 		return
 	}
@@ -80,12 +101,15 @@ func (r *Runner) tick(ctx context.Context, now time.Time) {
 	snap := BuildSnapshot(taken, positions, summary)
 	payload, err := MarshalSnapshot(snap)
 	if err != nil {
+		outcome = "skipped_marshal_error"
 		r.Log.Warn("marshal snapshot", "err", err)
 		return
 	}
 	if err := r.Client.PostSnapshotRetry(ctx, payload); err != nil {
+		outcome = "skipped_post_error"
 		r.Log.Warn("post snapshot", "err", err)
 		return
 	}
-	r.Log.Info("snapshot posted", "takenAt", snap.TakenAt)
+	outcome = "posted"
+	takenAt = snap.TakenAt
 }

--- a/internal/ingest/runner_test.go
+++ b/internal/ingest/runner_test.go
@@ -1,11 +1,14 @@
 package ingest
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +40,41 @@ func TestRunnerTickMock(t *testing.T) {
 	}
 	ctx := context.Background()
 	r.tick(ctx, time.Now())
+}
+
+func TestRunnerTick_emitsIngestTickSummary(t *testing.T) {
+	t.Setenv("MOCK_MARKET_OPEN", "true")
+	b := mock.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/internal/snapshots" && r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	r := &Runner{
+		Broker:   b,
+		Client:   NewClient(srv.URL, "k"),
+		Interval: time.Hour,
+		Log:      log,
+	}
+	r.tick(context.Background(), time.Now())
+
+	line := strings.TrimSpace(buf.String())
+	if !strings.Contains(line, `"msg":"ingest_tick"`) {
+		t.Fatalf("expected ingest_tick log, got: %s", line)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(line), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["tick_outcome"] != "posted" {
+		t.Fatalf("tick_outcome = %v", m["tick_outcome"])
+	}
 }
 
 func TestBuildSnapshot(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [.agent/epics/phase_1/logging/stories/story-04-ingest-tick-summary.md](.agent/epics/phase_1/logging/stories/story-04-ingest-tick-summary.md).

- One `ingest_tick` info line per tick with `tick_outcome`, `duration_ms`, `position_count`, optional `taken_at`
- Test asserts `tick_outcome=posted` on happy path
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

