### PR TITLE
P1 logging story 05: signals tick summary and docs

### DIFF
--- a/.agent/skills/logging.md
+++ b/.agent/skills/logging.md
@@ -1,0 +1,15 @@
+# Skill: Structured logging (`internal/logging`)
+
+Use when changing Go service logs. Epic: `.agent/epics/phase_1/logging/epic_P1_logging.md`.
+
+## Conventions
+
+- Attribute keys: **snake_case** (`request_id`, `duration_ms`, `rule_id`).
+- Never log passwords, session cookies, `X-Internal-Key`, or full Discord webhook URLs.
+
+## Env
+
+| Variable | Purpose |
+|----------|---------|
+| `LOG_LEVEL` | `debug` \| `info` \| `warn` \| `error` (default `info`) |
+| `APP_VERSION` | Optional string on every log line |

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Optional: structured logging for all Go binaries (JSON to stdout; Loki-friendly).
+# LOG_LEVEL=info   # debug | info | warn | error
+# APP_VERSION=dev  # optional; attached to every log line as "version"
+
 # Database
 POSTGRES_USER=portfolio
 POSTGRES_PASSWORD=changeme

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,17 +22,22 @@ morgans-d-stonks/
 ├── .gitignore
 ├── .github/workflows/ci.yml
 ├── .agent/
-│   └── epics/
-│       ├── phase_1/             # P0 (MVP) epics
-│       │   ├── foundation-homelab.md
-│       │   ├── ibkr-connectivity.md
-│       │   ├── portfolio-service.md
-│       │   ├── dashboard.md
-│       │   ├── ingest-snapshots.md
-│       │   └── signals-discord.md
-│       └── phase_2/             # P1 (first follow-up) epics
-│           ├── rich-alerts-dashboard-analytics.md
-│           └── openclaw-mcp-alerts.md
+│   ├── epics/
+│   │   ├── phase_1/             # P0 (MVP) epics
+│   │   │   ├── foundation-homelab.md
+│   │   │   ├── ibkr-connectivity.md
+│   │   │   ├── portfolio-service.md
+│   │   │   ├── dashboard.md
+│   │   │   ├── ingest-snapshots.md
+│   │   │   ├── signals-discord.md
+│   │   │   └── logging/         # P1 cross-cutting (stdout JSON for Loki)
+│   │   │       ├── epic_P1_logging.md
+│   │   │       └── stories/
+│   │   └── phase_2/             # P1 (first follow-up) epics
+│   │       ├── rich-alerts-dashboard-analytics.md
+│   │       └── openclaw-mcp-alerts.md
+│   └── skills/
+│       └── logging.md
 ├── apps/
 │   └── web/                     # Next.js dashboard
 ├── cmd/
@@ -47,6 +52,7 @@ morgans-d-stonks/
 │   ├── ingest/
 │   ├── signal/
 │   ├── discord/
+│   ├── logging/                 # P1 shared slog (epic_P1_logging)
 │   ├── openclaw/                # P1
 │   ├── mcp/                     # P1
 │   │   ├── portfolio/
@@ -61,11 +67,15 @@ morgans-d-stonks/
 
 ### How to read the epic files
 
-1. Read the instruction file for your assigned epic under `.agent/epics/phase_1/` or `phase_2/`.
+1. Read the instruction file for your assigned epic under `.agent/epics/phase_1/` or `phase_2/` (including nested dirs such as `phase_1/logging/`).
 2. Check the **Wave** and **Depends on** fields to understand ordering.
 3. Follow **Scope** for implementation details; respect **Do NOT** to avoid conflicts.
 4. Verify every item in **Acceptance criteria** before marking done.
 5. If a **Shared contract** must change, update all listed consuming epics.
+
+### Optional skills (checklists)
+
+For structured logging work, read `.agent/skills/logging.md` alongside `.agent/epics/phase_1/logging/epic_P1_logging.md`.
 
 ### Git workflow
 
@@ -113,6 +123,7 @@ Phase 2 (P1) ──────────────────────�
 │
 │  Wave 5:  SCH-22  Rich Alerts & Analytics  (parallel)
 │           SCH-23  OpenClaw, MCP & Alerts
+│           P1 logging (stdout JSON / Loki) — `phase_1/logging/epic_P1_logging.md`
 │
 ```
 
@@ -225,6 +236,8 @@ Owner: **SCH-23** | Consumer: OpenClaw agent
 | `OPENCLAW_API_URL` | openclaw-proxy | SCH-23 |
 | `OPENCLAW_API_KEY` | openclaw-proxy | SCH-23 |
 | `OPENCLAW_TIMEOUT` | openclaw-proxy | SCH-23 |
+| `LOG_LEVEL` | all Go services | P1 logging epic |
+| `APP_VERSION` | all Go services (optional) | P1 logging epic |
 
 ### Docker Compose service names
 
@@ -246,7 +259,7 @@ Owner: **SCH-23** | Consumer: OpenClaw agent
 - Interfaces defined by the consumer (except the shared `Broker`).
 - Error wrapping: `fmt.Errorf("context: %w", err)`.
 - Context propagation for all I/O.
-- Structured logging via `slog` (standard library) — use consistently across all services.
+- Structured logging via `slog` (standard library) — use consistently across all services; shared root logger in `internal/logging` (see `.agent/epics/phase_1/logging/epic_P1_logging.md`).
 
 ### TypeScript / Next.js
 

--- a/cmd/signals/main.go
+++ b/cmd/signals/main.go
@@ -82,6 +82,25 @@ func runOnce(
 	discordEnabled bool,
 	discordBotMention string,
 ) error {
+	start := time.Now()
+	ruleCount := len(rules)
+	eventsEvaluated := 0
+	eventsFired := 0
+	discordErrors := 0
+	eventsSent := 0 // successful Discord deliveries, or log-only emissions when Discord is disabled
+
+	defer func() {
+		log.Info("signals_tick",
+			"duration_ms", time.Since(start).Milliseconds(),
+			"rule_count", ruleCount,
+			"events_evaluated", eventsEvaluated,
+			"events_fired", eventsFired,
+			"events_sent", eventsSent,
+			"discord_enabled", discordEnabled,
+			"discord_errors", discordErrors,
+		)
+	}()
+
 	snap, err := fetchSnapshot(ctx, hc, baseURL, apiKey)
 	if err != nil {
 		return err
@@ -90,19 +109,30 @@ func runOnce(
 	if err != nil {
 		return err
 	}
+	eventsEvaluated = len(evs)
 	now := time.Now().UTC()
 	for _, ev := range evs {
 		if !ded.ShouldFire(ev.RuleID, ev.Symbol, cooldown, now) {
 			continue
 		}
+		eventsFired++
 		if !discordEnabled {
-			log.Info("signal", "event", ev.Signal, "value", ev.Value)
+			log.Info("signal",
+				"rule_id", ev.RuleID,
+				"symbol", ev.Symbol,
+				"event", ev.Signal,
+				"value", ev.Value,
+			)
+			eventsSent++
 			continue
 		}
 		msg := discord.SignalWebhookContent(discordBotMention, ev.Symbol, ev.RuleName)
 		if err := dc.SendMessage(ctx, msg); err != nil {
+			discordErrors++
 			log.Warn("discord", "err", err)
+			continue
 		}
+		eventsSent++
 	}
 	return nil
 }
@@ -126,7 +156,8 @@ func fetchSnapshot(ctx context.Context, hc *http.Client, baseURL, apiKey string)
 		return &portfolio.IngestSnapshotRequest{}, nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("portfolio: %s: %s", resp.Status, string(b))
+		// Do not include response body in errors (may leak snapshot or keys into logs).
+		return nil, fmt.Errorf("portfolio: snapshot fetch failed: status=%d", resp.StatusCode)
 	}
 	var snap portfolio.IngestSnapshotRequest
 	if err := json.Unmarshal(b, &snap); err != nil {

--- a/cmd/signals/signals_test.go
+++ b/cmd/signals/signals_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/schtvr/morgans-d-stonks/internal/discord"
+	sigpkg "github.com/schtvr/morgans-d-stonks/internal/signal"
+)
+
+func TestFetchSnapshot_doesNotLeakBodyInError(t *testing.T) {
+	secret := "SECRET_BODY_SHOULD_NOT_APPEAR"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, secret, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := fetchSnapshot(context.Background(), srv.Client(), srv.URL, "key")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error leaked body: %v", err)
+	}
+}
+
+func TestRunOnce_tickSummaryDiscordDisabled(t *testing.T) {
+	snapJSON := `{"takenAt":"2020-01-01T00:00:00Z","positions":[{"symbol":"AAPL","quantity":1,"avgCost":100,"marketValue":100,"unrealizedPLPct":-10}],"summary":{}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/snapshot/latest" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, snapJSON)
+	}))
+	defer srv.Close()
+
+	rules := []sigpkg.Rule{{
+		ID:   "r1",
+		Name: "drop",
+		Condition: sigpkg.Condition{
+			Type:      "price_change_pct",
+			Field:     "unrealizedPLPct",
+			Operator:  "lte",
+			Threshold: -5,
+		},
+	}}
+	ded, err := sigpkg.NewDedup(filepath.Join(t.TempDir(), "dedup.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	err = runOnce(context.Background(), log, srv.Client(), srv.URL, "k", rules, ded, time.Nanosecond, discord.NewClient(""), false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"msg":"signals_tick"`) {
+		t.Fatalf("missing signals_tick: %s", out)
+	}
+	if !strings.Contains(out, `"events_evaluated"`) {
+		t.Fatalf("missing summary fields: %s", out)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [.agent/epics/phase_1/logging/stories/story-05-signals-tick-summary.md](.agent/epics/phase_1/logging/stories/story-05-signals-tick-summary.md).

- `signals_tick` info summary with counts and `discord_errors`
- Per-fire `signal` logs include `rule_id` and `symbol`
- Portfolio non-2xx errors omit response body from error string
- Tests in `cmd/signals/signals_test.go`
- `.env.example` + `AGENTS.md` + `.agent/skills/logging.md` for epic acceptance / agent checklist
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

