### PR TITLE
P1 logging: stories, internal/logging, access and tick summaries

### DIFF
--- a/.agent/epics/phase_1/logging/stories/README.md
+++ b/.agent/epics/phase_1/logging/stories/README.md
@@ -1,0 +1,15 @@
+# P1 logging — agent stories
+
+Stories derived from [epic_P1_logging.md](../epic_P1_logging.md). Execute **in order** (01 → 05) to minimize merge conflicts.
+
+| # | File | PR branch (suggested) |
+|---|------|------------------------|
+| 01 | [story-01-internal-logging-package.md](./story-01-internal-logging-package.md) | `cursor/p1-logging-story-01-internal-logging` |
+| 02 | [story-02-wire-cmd-loggers.md](./story-02-wire-cmd-loggers.md) | `cursor/p1-logging-story-02-wire-cmd` |
+| 03 | [story-03-portfolio-api-access-logs.md](./story-03-portfolio-api-access-logs.md) | `cursor/p1-logging-story-03-access-logs` |
+| 04 | [story-04-ingest-tick-summary.md](./story-04-ingest-tick-summary.md) | `cursor/p1-logging-story-04-ingest-tick` |
+| 05 | [story-05-signals-tick-summary.md](./story-05-signals-tick-summary.md) | `cursor/p1-logging-story-05-signals-tick` |
+
+**Integration branch**: `cursor/p1-logging` (stories land first; each story PR targets this branch).
+
+Before coding, read [.agent/skills/logging.md](../../../../skills/logging.md).

--- a/.agent/epics/phase_1/logging/stories/story-01-internal-logging-package.md
+++ b/.agent/epics/phase_1/logging/stories/story-01-internal-logging-package.md
@@ -1,0 +1,40 @@
+# Story 01 — `internal/logging` package
+
+**Epic**: [epic_P1_logging.md](../epic_P1_logging.md)  
+**Branch for PR**: `cursor/p1-logging-story-01-internal-logging`  
+**PR merges into**: `cursor/p1-logging`  
+**Depends on**: none (base branch already has epic + stories)
+
+## Goal
+
+Add `internal/logging` so every binary can construct a JSON `slog` logger to stdout with `service`, optional `version`, and env-driven level.
+
+## Requirements
+
+1. **API** (names may vary; keep idiomatic Go):
+   - `New(service string) *slog.Logger` — reads `LOG_LEVEL` and `APP_VERSION` from the environment (use `os.Getenv` only in this package or in `main` passing values in — prefer **one place**: `NewFromEnv` with `os.Getenv` inside `internal/logging` is fine for this epic).
+   - JSON handler → **stdout**.
+2. **`LOG_LEVEL`**: `debug`, `info`, `warn`, `error` (case-insensitive). Empty or invalid → **`info`** and **one** diagnostic line to **stderr** (not JSON logger) explaining the fallback.
+3. **`APP_VERSION`**: optional; if non-empty, add attribute `version` to every log via `Logger.With`.
+4. **Required attribute**: `service` on every emitted record (non-empty string from caller).
+5. **Tests** (`internal/logging/logger_test.go`):
+   - Level parsing / behavior for valid levels (e.g. `debug` emits debug record when logged).
+   - JSON output contains `"service":"test-service"` (decode one line).
+   - Invalid `LOG_LEVEL` falls back to info (assert default behavior).
+
+## Out of scope
+
+- Wiring `cmd/*` (Story 02).
+- HTTP access middleware (Story 03).
+
+## Definition of done
+
+- [ ] `go test ./...` passes.
+- [ ] No new third-party logging dependencies.
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Create | `internal/logging/logger.go` |
+| Create | `internal/logging/logger_test.go` |

--- a/.agent/epics/phase_1/logging/stories/story-02-wire-cmd-loggers.md
+++ b/.agent/epics/phase_1/logging/stories/story-02-wire-cmd-loggers.md
@@ -1,0 +1,36 @@
+# Story 02 — Wire all Go `cmd/*` binaries to `internal/logging`
+
+**Epic**: [epic_P1_logging.md](../epic_P1_logging.md)  
+**Branch for PR**: `cursor/p1-logging-story-02-wire-cmd`  
+**PR merges into**: `cursor/p1-logging`  
+**Depends on**: Story 01 merged into `cursor/p1-logging`
+
+## Goal
+
+Remove ad-hoc `slog.New(slog.NewJSONHandler(os.Stdout, …))` from entrypoints; use `internal/logging` with a **distinct `service` value per binary**.
+
+## Requirements
+
+1. **`portfolio-api`**: `service=portfolio-api`.
+2. **`ingest`**: `service=ingest`.
+3. **`signals`**: `service=signals`.
+4. **`internal/ingest` Runner** fallback when `Log == nil`: must still produce JSON with `service=ingest` — either set logger in `cmd/ingest` before `Run` (already does) and change fallback to use `internal/logging.New("ingest")`, or document that Runner always receives non-nil `Log` after this story; **prefer** non-nil from `main` + safe fallback using `internal/logging` for consistency.
+
+## Out of scope
+
+- Access log middleware (Story 03).
+- Tick summary fields beyond what already exists (Stories 04–05).
+
+## Definition of done
+
+- [ ] `grep -R "NewJSONHandler" cmd` shows no remaining direct stdout JSON handler setup in `cmd/` (Runner fallback allowed only via `internal/logging`).
+- [ ] `go test ./...` passes.
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Modify | `cmd/portfolio-api/main.go` |
+| Modify | `cmd/ingest/main.go` |
+| Modify | `cmd/signals/main.go` |
+| Modify | `internal/ingest/runner.go` (fallback logger only, if needed) |

--- a/.agent/epics/phase_1/logging/stories/story-03-portfolio-api-access-logs.md
+++ b/.agent/epics/phase_1/logging/stories/story-03-portfolio-api-access-logs.md
@@ -1,0 +1,48 @@
+# Story 03 — `portfolio-api` structured access logs + request correlation
+
+**Epic**: [epic_P1_logging.md](../epic_P1_logging.md)  
+**Branch for PR**: `cursor/p1-logging-story-03-access-logs`  
+**PR merges into**: `cursor/p1-logging`  
+**Depends on**: Story 02 merged into `cursor/p1-logging`
+
+## Goal
+
+Emit **one JSON log line per HTTP request** after the response completes, suitable for Loki queries and correlation with handler logs.
+
+## Log fields (snake_case)
+
+Minimum on every access line:
+
+| Field | Source |
+|--------|--------|
+| `msg` | fixed string e.g. `http_request` |
+| `method` | `r.Method` |
+| `path` | chi **route pattern** if available after routing; else `r.URL.Path` (no query string) |
+| `status` | HTTP status code |
+| `duration_ms` | integer elapsed milliseconds |
+| `bytes` | response bytes written (best effort via wrapped `ResponseWriter`) |
+| `request_id` | chi `middleware.GetReqID(r)` |
+
+## Middleware order
+
+Register access middleware **after** `RequestID` so `request_id` is populated. It must run for **all** routes including `/api/health` and `/internal/*`.
+
+## Redaction / safety
+
+- Do **not** log: `Authorization`, `Cookie` / session values, request bodies, or `X-Internal-Key`.
+- Access middleware should only use request metadata listed above.
+
+## Optional (nice to have)
+
+- Attach `*slog.Logger` with `request_id` to `r.Context()` using `slog.With` so handlers can log with the same id — only if small; otherwise skip.
+
+## Definition of done
+
+- [ ] Manual or test verification: hit `/api/health` and see one access line with `status=200`, `request_id` non-empty.
+- [ ] `go test ./...` passes (add `httptest` test if straightforward).
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Modify | `cmd/portfolio-api/main.go` (middleware; may extract to `internal/logging/middleware.go` if kept tiny) |

--- a/.agent/epics/phase_1/logging/stories/story-04-ingest-tick-summary.md
+++ b/.agent/epics/phase_1/logging/stories/story-04-ingest-tick-summary.md
@@ -1,0 +1,31 @@
+# Story 04 — `ingest` INFO tick summary for Loki dashboards
+
+**Epic**: [epic_P1_logging.md](../epic_P1_logging.md)  
+**Branch for PR**: `cursor/p1-logging-story-04-ingest-tick`  
+**PR merges into**: `cursor/p1-logging`  
+**Depends on**: Story 02 merged into `cursor/p1-logging` (Story 03 can land before or after; no file conflict expected)
+
+## Goal
+
+Each ingest **tick** emits a single **`info`** summary suitable for “last successful run” / error-rate panels, without per-position spam.
+
+## Requirements
+
+1. At **tick** granularity, log **one structured `info` line** when the tick completes (success, skip, or early return), including at minimum:
+   - `duration_ms` (full tick wall time)
+   - `tick_outcome` — small enum, e.g. `posted`, `skipped_market_closed`, `skipped_broker_error`, `skipped_post_error`, etc.
+   - When snapshot successfully posted: `position_count`, `taken_at` (UTC timestamp from snapshot) if available
+2. Existing **`warn`** lines for broker/post errors may remain; ensure they do **not** include full HTTP response bodies from the portfolio API (status or short message only).
+3. Field names **snake_case** per `.agent/skills/logging.md`.
+
+## Definition of done
+
+- [ ] `go test ./...` passes.
+- [ ] `internal/ingest` tests updated or added if timing/outcome logic is extracted for testability.
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Modify | `internal/ingest/runner.go` |
+| Modify | `internal/ingest/runner_test.go` (if needed) |

--- a/.agent/epics/phase_1/logging/stories/story-05-signals-tick-summary.md
+++ b/.agent/epics/phase_1/logging/stories/story-05-signals-tick-summary.md
@@ -1,0 +1,34 @@
+# Story 05 — `signals` INFO tick summary + safe errors
+
+**Epic**: [epic_P1_logging.md](../epic_P1_logging.md)  
+**Branch for PR**: `cursor/p1-logging-story-05-signals-tick`  
+**PR merges into**: `cursor/p1-logging`  
+**Depends on**: Story 02 merged into `cursor/p1-logging`
+
+## Goal
+
+Each signals **tick** emits one **`info`** summary; per-fire logs include **`rule_id`** and **`symbol`**; never log secrets or full error bodies from upstream.
+
+## Requirements
+
+1. **Per-tick `info` summary** after evaluation/send loop, including at minimum:
+   - `duration_ms`
+   - `rule_count` (rules loaded)
+   - `events_evaluated` (count of firing candidates from engine — typically `len(evs)`)
+   - `events_sent` (Discord sends attempted or log-only fires; define clearly in code comments)
+   - `discord_enabled` (bool)
+   - `discord_errors` (count of failed Discord posts in that tick)
+2. **Per-fire** log when Discord disabled (existing path): add `rule_id`, `symbol` (and keep human-readable signal text if present).
+3. **`fetchSnapshot` / errors**: do not include raw portfolio response **body** in errors that may be logged (avoid leaking internal payloads); status code is enough for operators.
+4. Never log `DISCORD_WEBHOOK_URL`, `X-Internal-Key`, or session material.
+
+## Definition of done
+
+- [ ] `go test ./...` passes.
+- [ ] Add or extend tests for `runOnce` summary counts if extracted for testability.
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Modify | `cmd/signals/main.go` |

--- a/.agent/skills/logging.md
+++ b/.agent/skills/logging.md
@@ -1,0 +1,15 @@
+# Skill: Structured logging (`internal/logging`)
+
+Use when changing Go service logs. Epic: `.agent/epics/phase_1/logging/epic_P1_logging.md`.
+
+## Conventions
+
+- Attribute keys: **snake_case** (`request_id`, `duration_ms`, `rule_id`).
+- Never log passwords, session cookies, `X-Internal-Key`, or full Discord webhook URLs.
+
+## Env
+
+| Variable | Purpose |
+|----------|---------|
+| `LOG_LEVEL` | `debug` \| `info` \| `warn` \| `error` (default `info`) |
+| `APP_VERSION` | Optional string on every log line |

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Optional: structured logging for all Go binaries (JSON to stdout; Loki-friendly).
+# LOG_LEVEL=info   # debug | info | warn | error
+# APP_VERSION=dev  # optional; attached to every log line as "version"
+
 # Database
 POSTGRES_USER=portfolio
 POSTGRES_PASSWORD=changeme

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,17 +22,22 @@ morgans-d-stonks/
 ├── .gitignore
 ├── .github/workflows/ci.yml
 ├── .agent/
-│   └── epics/
-│       ├── phase_1/             # P0 (MVP) epics
-│       │   ├── foundation-homelab.md
-│       │   ├── ibkr-connectivity.md
-│       │   ├── portfolio-service.md
-│       │   ├── dashboard.md
-│       │   ├── ingest-snapshots.md
-│       │   └── signals-discord.md
-│       └── phase_2/             # P1 (first follow-up) epics
-│           ├── rich-alerts-dashboard-analytics.md
-│           └── openclaw-mcp-alerts.md
+│   ├── epics/
+│   │   ├── phase_1/             # P0 (MVP) epics
+│   │   │   ├── foundation-homelab.md
+│   │   │   ├── ibkr-connectivity.md
+│   │   │   ├── portfolio-service.md
+│   │   │   ├── dashboard.md
+│   │   │   ├── ingest-snapshots.md
+│   │   │   ├── signals-discord.md
+│   │   │   └── logging/         # P1 cross-cutting (stdout JSON for Loki)
+│   │   │       ├── epic_P1_logging.md
+│   │   │       └── stories/
+│   │   └── phase_2/             # P1 (first follow-up) epics
+│   │       ├── rich-alerts-dashboard-analytics.md
+│   │       └── openclaw-mcp-alerts.md
+│   └── skills/
+│       └── logging.md
 ├── apps/
 │   └── web/                     # Next.js dashboard
 ├── cmd/
@@ -47,6 +52,7 @@ morgans-d-stonks/
 │   ├── ingest/
 │   ├── signal/
 │   ├── discord/
+│   ├── logging/                 # P1 shared slog (epic_P1_logging)
 │   ├── openclaw/                # P1
 │   ├── mcp/                     # P1
 │   │   ├── portfolio/
@@ -61,11 +67,15 @@ morgans-d-stonks/
 
 ### How to read the epic files
 
-1. Read the instruction file for your assigned epic under `.agent/epics/phase_1/` or `phase_2/`.
+1. Read the instruction file for your assigned epic under `.agent/epics/phase_1/` or `phase_2/` (including nested dirs such as `phase_1/logging/`).
 2. Check the **Wave** and **Depends on** fields to understand ordering.
 3. Follow **Scope** for implementation details; respect **Do NOT** to avoid conflicts.
 4. Verify every item in **Acceptance criteria** before marking done.
 5. If a **Shared contract** must change, update all listed consuming epics.
+
+### Optional skills (checklists)
+
+For structured logging work, read `.agent/skills/logging.md` alongside `.agent/epics/phase_1/logging/epic_P1_logging.md`.
 
 ### Git workflow
 
@@ -113,6 +123,7 @@ Phase 2 (P1) ──────────────────────�
 │
 │  Wave 5:  SCH-22  Rich Alerts & Analytics  (parallel)
 │           SCH-23  OpenClaw, MCP & Alerts
+│           P1 logging (stdout JSON / Loki) — `phase_1/logging/epic_P1_logging.md`
 │
 ```
 
@@ -225,6 +236,8 @@ Owner: **SCH-23** | Consumer: OpenClaw agent
 | `OPENCLAW_API_URL` | openclaw-proxy | SCH-23 |
 | `OPENCLAW_API_KEY` | openclaw-proxy | SCH-23 |
 | `OPENCLAW_TIMEOUT` | openclaw-proxy | SCH-23 |
+| `LOG_LEVEL` | all Go services | P1 logging epic |
+| `APP_VERSION` | all Go services (optional) | P1 logging epic |
 
 ### Docker Compose service names
 
@@ -246,7 +259,7 @@ Owner: **SCH-23** | Consumer: OpenClaw agent
 - Interfaces defined by the consumer (except the shared `Broker`).
 - Error wrapping: `fmt.Errorf("context: %w", err)`.
 - Context propagation for all I/O.
-- Structured logging via `slog` (standard library) — use consistently across all services.
+- Structured logging via `slog` (standard library) — use consistently across all services; shared root logger in `internal/logging` (see `.agent/epics/phase_1/logging/epic_P1_logging.md`).
 
 ### TypeScript / Next.js
 

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -2,17 +2,17 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"time"
 
 	"github.com/schtvr/morgans-d-stonks/internal/broker"
 	"github.com/schtvr/morgans-d-stonks/internal/brokerwire"
 	"github.com/schtvr/morgans-d-stonks/internal/ingest"
+	"github.com/schtvr/morgans-d-stonks/internal/logging"
 )
 
 func main() {
-	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	log := logging.New("ingest")
 
 	cfg := broker.LoadConfigFromEnv()
 	br, err := brokerwire.New(cfg)

--- a/cmd/portfolio-api/main.go
+++ b/cmd/portfolio-api/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/schtvr/morgans-d-stonks/internal/auth"
 	"github.com/schtvr/morgans-d-stonks/internal/config"
+	"github.com/schtvr/morgans-d-stonks/internal/logging"
 	"github.com/schtvr/morgans-d-stonks/internal/portfolio"
 	pgstore "github.com/schtvr/morgans-d-stonks/internal/portfolio/postgres"
 )
@@ -26,7 +27,7 @@ import (
 // REST API for portfolio snapshots and single-user session auth (SCH-18).
 func main() {
 	cfg := config.LoadPortfolioAPI()
-	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	log := logging.New("portfolio-api")
 
 	if cfg.DatabaseURL == "" {
 		log.Error("DATABASE_URL is required")

--- a/cmd/portfolio-api/main.go
+++ b/cmd/portfolio-api/main.go
@@ -53,6 +53,7 @@ func main() {
 	r.Use(chimiddleware.RequestID)
 	r.Use(chimiddleware.RealIP)
 	r.Use(chimiddleware.Recoverer)
+	r.Use(logging.AccessLog(log))
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   cfg.CORSAllowedOrigins,
 		AllowedMethods:   []string{"GET", "POST", "OPTIONS"},

--- a/cmd/signals/main.go
+++ b/cmd/signals/main.go
@@ -82,6 +82,25 @@ func runOnce(
 	discordEnabled bool,
 	discordBotMention string,
 ) error {
+	start := time.Now()
+	ruleCount := len(rules)
+	eventsEvaluated := 0
+	eventsFired := 0
+	discordErrors := 0
+	eventsSent := 0 // successful Discord deliveries, or log-only emissions when Discord is disabled
+
+	defer func() {
+		log.Info("signals_tick",
+			"duration_ms", time.Since(start).Milliseconds(),
+			"rule_count", ruleCount,
+			"events_evaluated", eventsEvaluated,
+			"events_fired", eventsFired,
+			"events_sent", eventsSent,
+			"discord_enabled", discordEnabled,
+			"discord_errors", discordErrors,
+		)
+	}()
+
 	snap, err := fetchSnapshot(ctx, hc, baseURL, apiKey)
 	if err != nil {
 		return err
@@ -90,19 +109,30 @@ func runOnce(
 	if err != nil {
 		return err
 	}
+	eventsEvaluated = len(evs)
 	now := time.Now().UTC()
 	for _, ev := range evs {
 		if !ded.ShouldFire(ev.RuleID, ev.Symbol, cooldown, now) {
 			continue
 		}
+		eventsFired++
 		if !discordEnabled {
-			log.Info("signal", "event", ev.Signal, "value", ev.Value)
+			log.Info("signal",
+				"rule_id", ev.RuleID,
+				"symbol", ev.Symbol,
+				"event", ev.Signal,
+				"value", ev.Value,
+			)
+			eventsSent++
 			continue
 		}
 		msg := discord.SignalWebhookContent(discordBotMention, ev.Symbol, ev.RuleName)
 		if err := dc.SendMessage(ctx, msg); err != nil {
+			discordErrors++
 			log.Warn("discord", "err", err)
+			continue
 		}
+		eventsSent++
 	}
 	return nil
 }
@@ -126,7 +156,8 @@ func fetchSnapshot(ctx context.Context, hc *http.Client, baseURL, apiKey string)
 		return &portfolio.IngestSnapshotRequest{}, nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("portfolio: %s: %s", resp.Status, string(b))
+		// Do not include response body in errors (may leak snapshot or keys into logs).
+		return nil, fmt.Errorf("portfolio: snapshot fetch failed: status=%d", resp.StatusCode)
 	}
 	var snap portfolio.IngestSnapshotRequest
 	if err := json.Unmarshal(b, &snap); err != nil {

--- a/cmd/signals/main.go
+++ b/cmd/signals/main.go
@@ -14,12 +14,13 @@ import (
 
 	"github.com/schtvr/morgans-d-stonks/internal/config"
 	"github.com/schtvr/morgans-d-stonks/internal/discord"
+	"github.com/schtvr/morgans-d-stonks/internal/logging"
 	"github.com/schtvr/morgans-d-stonks/internal/portfolio"
 	sigpkg "github.com/schtvr/morgans-d-stonks/internal/signal"
 )
 
 func main() {
-	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	log := logging.New("signals")
 
 	cfg := config.LoadSignals()
 

--- a/cmd/signals/signals_test.go
+++ b/cmd/signals/signals_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/schtvr/morgans-d-stonks/internal/discord"
+	sigpkg "github.com/schtvr/morgans-d-stonks/internal/signal"
+)
+
+func TestFetchSnapshot_doesNotLeakBodyInError(t *testing.T) {
+	secret := "SECRET_BODY_SHOULD_NOT_APPEAR"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, secret, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := fetchSnapshot(context.Background(), srv.Client(), srv.URL, "key")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error leaked body: %v", err)
+	}
+}
+
+func TestRunOnce_tickSummaryDiscordDisabled(t *testing.T) {
+	snapJSON := `{"takenAt":"2020-01-01T00:00:00Z","positions":[{"symbol":"AAPL","quantity":1,"avgCost":100,"marketValue":100,"unrealizedPLPct":-10}],"summary":{}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/snapshot/latest" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, snapJSON)
+	}))
+	defer srv.Close()
+
+	rules := []sigpkg.Rule{{
+		ID:   "r1",
+		Name: "drop",
+		Condition: sigpkg.Condition{
+			Type:      "price_change_pct",
+			Field:     "unrealizedPLPct",
+			Operator:  "lte",
+			Threshold: -5,
+		},
+	}}
+	ded, err := sigpkg.NewDedup(filepath.Join(t.TempDir(), "dedup.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	err = runOnce(context.Background(), log, srv.Client(), srv.URL, "k", rules, ded, time.Nanosecond, discord.NewClient(""), false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"msg":"signals_tick"`) {
+		t.Fatalf("missing signals_tick: %s", out)
+	}
+	if !strings.Contains(out, `"events_evaluated"`) {
+		t.Fatalf("missing summary fields: %s", out)
+	}
+}

--- a/internal/ingest/runner.go
+++ b/internal/ingest/runner.go
@@ -47,23 +47,44 @@ func (r *Runner) Run(ctx context.Context) error {
 
 func (r *Runner) tick(ctx context.Context, now time.Time) {
 	_ = now
+	start := time.Now()
+	outcome := "unknown"
+	positionCount := 0
+	var takenAt time.Time
+
+	defer func() {
+		attrs := []any{
+			"tick_outcome", outcome,
+			"duration_ms", time.Since(start).Milliseconds(),
+			"position_count", positionCount,
+		}
+		if !takenAt.IsZero() {
+			attrs = append(attrs, "taken_at", takenAt.UTC())
+		}
+		r.Log.Info("ingest_tick", attrs...)
+	}()
+
 	open, err := r.Broker.IsMarketOpen(ctx)
 	if err != nil {
+		outcome = "skipped_broker_market_check"
 		r.Log.Warn("broker market check", "err", err)
 		return
 	}
 	if !open {
-		r.Log.Info("market closed; skipping tick")
+		outcome = "skipped_market_closed"
 		return
 	}
 
 	positions, err := r.Broker.Positions(ctx)
 	if err != nil {
+		outcome = "skipped_broker_positions"
 		r.Log.Warn("broker positions", "err", err)
 		return
 	}
+	positionCount = len(positions)
 	summary, err := r.Broker.AccountSummary(ctx)
 	if err != nil {
+		outcome = "skipped_broker_summary"
 		r.Log.Warn("broker summary", "err", err)
 		return
 	}
@@ -80,12 +101,15 @@ func (r *Runner) tick(ctx context.Context, now time.Time) {
 	snap := BuildSnapshot(taken, positions, summary)
 	payload, err := MarshalSnapshot(snap)
 	if err != nil {
+		outcome = "skipped_marshal_error"
 		r.Log.Warn("marshal snapshot", "err", err)
 		return
 	}
 	if err := r.Client.PostSnapshotRetry(ctx, payload); err != nil {
+		outcome = "skipped_post_error"
 		r.Log.Warn("post snapshot", "err", err)
 		return
 	}
-	r.Log.Info("snapshot posted", "takenAt", snap.TakenAt)
+	outcome = "posted"
+	takenAt = snap.TakenAt
 }

--- a/internal/ingest/runner.go
+++ b/internal/ingest/runner.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/schtvr/morgans-d-stonks/internal/broker"
+	"github.com/schtvr/morgans-d-stonks/internal/logging"
 )
 
 // Runner orchestrates periodic snapshot ingestion.
@@ -22,7 +23,7 @@ type Runner struct {
 // Run blocks until SIGINT/SIGTERM, executing ticks on Interval.
 func (r *Runner) Run(ctx context.Context) error {
 	if r.Log == nil {
-		r.Log = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+		r.Log = logging.New("ingest")
 	}
 	t := time.NewTicker(r.Interval)
 	defer t.Stop()

--- a/internal/ingest/runner_test.go
+++ b/internal/ingest/runner_test.go
@@ -1,11 +1,14 @@
 package ingest
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +40,41 @@ func TestRunnerTickMock(t *testing.T) {
 	}
 	ctx := context.Background()
 	r.tick(ctx, time.Now())
+}
+
+func TestRunnerTick_emitsIngestTickSummary(t *testing.T) {
+	t.Setenv("MOCK_MARKET_OPEN", "true")
+	b := mock.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/internal/snapshots" && r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	r := &Runner{
+		Broker:   b,
+		Client:   NewClient(srv.URL, "k"),
+		Interval: time.Hour,
+		Log:      log,
+	}
+	r.tick(context.Background(), time.Now())
+
+	line := strings.TrimSpace(buf.String())
+	if !strings.Contains(line, `"msg":"ingest_tick"`) {
+		t.Fatalf("expected ingest_tick log, got: %s", line)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(line), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["tick_outcome"] != "posted" {
+		t.Fatalf("tick_outcome = %v", m["tick_outcome"])
+	}
 }
 
 func TestBuildSnapshot(t *testing.T) {

--- a/internal/logging/access.go
+++ b/internal/logging/access.go
@@ -1,0 +1,46 @@
+package logging
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+)
+
+// AccessLog returns chi middleware that emits one JSON log line per request after completion.
+// Fields: msg=http_request, method, path (route pattern when available), status, duration_ms, bytes, request_id.
+func AccessLog(log *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			ww := chimiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			next.ServeHTTP(ww, r)
+
+			path := requestPath(r)
+			log.Info("http_request",
+				"method", r.Method,
+				"path", path,
+				"status", ww.Status(),
+				"duration_ms", time.Since(start).Milliseconds(),
+				"bytes", ww.BytesWritten(),
+				"request_id", chimiddleware.GetReqID(r.Context()),
+			)
+		})
+	}
+}
+
+func requestPath(r *http.Request) string {
+	if rc := chi.RouteContext(r.Context()); rc != nil {
+		if p := rc.RoutePattern(); p != "" {
+			return p
+		}
+	}
+	p := r.URL.Path
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		return p[:i]
+	}
+	return p
+}

--- a/internal/logging/access_test.go
+++ b/internal/logging/access_test.go
@@ -1,0 +1,52 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+)
+
+func TestAccessLog_emitsJSONWithRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	r := chi.NewRouter()
+	r.Use(chimiddleware.RequestID)
+	r.Use(AccessLog(log))
+	r.Get("/api/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"status":"ok"}`)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["msg"] != "http_request" {
+		t.Fatalf("msg = %v", m["msg"])
+	}
+	if m["method"] != "GET" {
+		t.Fatalf("method = %v", m["method"])
+	}
+	if m["path"] != "/api/health" {
+		t.Fatalf("path = %v", m["path"])
+	}
+	if m["status"] != float64(200) { // json numbers
+		t.Fatalf("status = %v", m["status"])
+	}
+	rid, _ := m["request_id"].(string)
+	if rid == "" {
+		t.Fatal("expected request_id")
+	}
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,53 @@
+// Package logging provides a shared JSON slog logger for service stdout (Loki-friendly).
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// New returns a JSON slog.Logger to stdout with attrs service, optional version,
+// and level from LOG_LEVEL (default info). Invalid LOG_LEVEL writes one line to stderr and uses info.
+func New(service string) *slog.Logger {
+	return newLogger(service, os.Getenv("LOG_LEVEL"), os.Getenv("APP_VERSION"), os.Stdout, os.Stderr)
+}
+
+func newLogger(service, logLevelEnv, appVersion string, out, errOut io.Writer) *slog.Logger {
+	if service == "" {
+		service = "unknown"
+	}
+	level, ok := parseLevel(logLevelEnv)
+	if !ok && strings.TrimSpace(logLevelEnv) != "" {
+		_, _ = fmt.Fprintf(errOut, "logging: invalid LOG_LEVEL=%q, using info\n", logLevelEnv)
+		level = slog.LevelInfo
+	}
+	opts := &slog.HandlerOptions{Level: level}
+	h := slog.NewJSONHandler(out, opts)
+	var lg *slog.Logger
+	if v := strings.TrimSpace(appVersion); v != "" {
+		lg = slog.New(h).With("service", service, "version", v)
+	} else {
+		lg = slog.New(h).With("service", service)
+	}
+	return lg
+}
+
+func parseLevel(s string) (slog.Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return slog.LevelInfo, true
+	case "debug":
+		return slog.LevelDebug, true
+	case "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error":
+		return slog.LevelError, true
+	default:
+		return slog.LevelInfo, false
+	}
+}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,104 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestParseLevel_valid(t *testing.T) {
+	tests := []struct {
+		in   string
+		want slog.Level
+	}{
+		{"", slog.LevelInfo},
+		{"  ", slog.LevelInfo},
+		{"info", slog.LevelInfo},
+		{"INFO", slog.LevelInfo},
+		{"debug", slog.LevelDebug},
+		{"warn", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"error", slog.LevelError},
+	}
+	for _, tt := range tests {
+		got, ok := parseLevel(tt.in)
+		if !ok {
+			t.Fatalf("parseLevel(%q): expected ok", tt.in)
+		}
+		if got != tt.want {
+			t.Fatalf("parseLevel(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParseLevel_invalid(t *testing.T) {
+	_, ok := parseLevel("nope")
+	if ok {
+		t.Fatal("expected invalid")
+	}
+}
+
+func TestNewLogger_JSONContainsService(t *testing.T) {
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	log := newLogger("test-service", "info", "", &out, &errBuf)
+	log.Info("hello", "k", 1)
+	if errBuf.Len() != 0 {
+		t.Fatalf("stderr: %s", errBuf.String())
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out.Bytes(), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["service"] != "test-service" {
+		t.Fatalf("service = %v", m["service"])
+	}
+	if m["msg"] != "hello" {
+		t.Fatalf("msg = %v", m["msg"])
+	}
+}
+
+func TestNewLogger_versionAttr(t *testing.T) {
+	var out bytes.Buffer
+	log := newLogger("ingest", "info", "1.2.3", &out, io.Discard)
+	log.Warn("x")
+	var m map[string]any
+	_ = json.Unmarshal(out.Bytes(), &m)
+	if m["version"] != "1.2.3" {
+		t.Fatalf("version = %v", m["version"])
+	}
+}
+
+func TestNewLogger_invalidLevelFallbackAndStderr(t *testing.T) {
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	log := newLogger("svc", "bogus", "", &out, &errBuf)
+	if !strings.Contains(errBuf.String(), "invalid LOG_LEVEL") {
+		t.Fatalf("expected stderr warning, got %q", errBuf.String())
+	}
+	// Fallback info: debug should not appear
+	if log.Enabled(nil, slog.LevelDebug) {
+		t.Fatal("expected info level")
+	}
+	log.Info("ok")
+	var m map[string]any
+	_ = json.Unmarshal(out.Bytes(), &m)
+	if m["msg"] != "ok" {
+		t.Fatalf("msg = %v", m["msg"])
+	}
+}
+
+func TestNewLogger_debugLevel(t *testing.T) {
+	var out bytes.Buffer
+	log := newLogger("svc", "debug", "", &out, io.Discard)
+	if !log.Enabled(nil, slog.LevelDebug) {
+		t.Fatal("expected debug enabled")
+	}
+	log.Debug("trace")
+	if !bytes.Contains(out.Bytes(), []byte(`"msg":"trace"`)) {
+		t.Fatalf("output: %s", out.String())
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Integration branch for **P1 structured logging** (Loki-friendly JSON on stdout): agent story files under `.agent/epics/phase_1/logging/stories/`, shared `internal/logging`, `portfolio-api` access middleware, ingest/signals tick summaries, tests, and doc updates.

## Story PRs (all merged here)

- #9 — `internal/logging` package
- #10 — Wire `cmd/*` to shared logger
- #11 — `portfolio-api` access logs (`AccessLog` middleware)
- #12 — Ingest `ingest_tick` summary
- #13 — Signals `signals_tick` summary + tests + `.env.example` / `AGENTS.md` / skill

## How to review

- `go test ./...`
- Epic: `.agent/epics/phase_1/logging/epic_P1_logging.md`

## Merge target

Merge this branch into **`phase-1`** when ready (stacked story PRs target `cursor/p1-logging` only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88c75155-6adc-4317-8582-ce20d1cd5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

