### PR TITLE
Security: internal API key requirement and hardened dashboard session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ AUTH_USERNAME=admin
 AUTH_PASSWORD=changeme
 AUTH_SECRET=changeme-32-char-min
 
-# Internal API (ingest → portfolio-api)
+# Internal API (ingest/signals → portfolio-api; required — portfolio-api refuses empty)
 INTERNAL_API_KEY=changeme
 
 # Ingest

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -5,8 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { apiBaseUrl } from "@/lib/api";
-import { setToken } from "@/lib/auth";
+import { apiBaseUrl, isCrossOriginPublicAPI, setCrossOriginBearerToken } from "@/lib/api";
+import { markSessionPresent } from "@/lib/auth";
 
 export default function LoginPage() {
   const [username, setUsername] = useState("admin");
@@ -19,9 +19,14 @@ export default function LoginPage() {
     setLoading(true);
     setError(null);
     try {
+      const crossOrigin = isCrossOriginPublicAPI();
       const res = await fetch(`${apiBaseUrl()}/api/auth/login`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Accept: crossOrigin ? "application/json" : "text/html",
+        },
+        credentials: "include",
         body: JSON.stringify({ username, password }),
       });
       if (!res.ok) {
@@ -29,8 +34,11 @@ export default function LoginPage() {
         setLoading(false);
         return;
       }
-      const data = (await res.json()) as { token: string };
-      setToken(data.token);
+      const body = (await res.json().catch(() => null)) as { token?: string } | null;
+      if (crossOrigin && body?.token) {
+        setCrossOriginBearerToken(body.token);
+      }
+      markSessionPresent();
       window.location.href = "/";
     } catch {
       setError("Could not reach API");

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -4,8 +4,8 @@ import Link from "next/link";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
-import { clearToken } from "@/lib/auth";
-import { apiFetch } from "@/lib/api";
+import { clearSessionMarker } from "@/lib/auth";
+import { apiFetch, clearCrossOriginBearerToken } from "@/lib/api";
 
 export function SiteHeader() {
   const { theme, setTheme } = useTheme();
@@ -16,7 +16,8 @@ export function SiteHeader() {
     } catch {
       // ignore
     }
-    clearToken();
+    clearSessionMarker();
+    clearCrossOriginBearerToken();
     window.location.href = "/login";
   }
 

--- a/apps/web/lib/api.test.ts
+++ b/apps/web/lib/api.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { apiBaseUrl, isCrossOriginPublicAPI } from "./api";
+
+describe("apiBaseUrl", () => {
+  it("trims trailing slash from NEXT_PUBLIC_API_URL", () => {
+    const prev = process.env.NEXT_PUBLIC_API_URL;
+    process.env.NEXT_PUBLIC_API_URL = "http://example.com:8080/";
+    expect(apiBaseUrl()).toBe("http://example.com:8080");
+    process.env.NEXT_PUBLIC_API_URL = prev;
+  });
+});
+
+describe("isCrossOriginPublicAPI", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  it("returns false when NEXT_PUBLIC_API_URL is unset", () => {
+    vi.stubGlobal("window", { location: { origin: "http://localhost:3000" } });
+    expect(isCrossOriginPublicAPI()).toBe(false);
+  });
+
+  it("returns true when public API origin differs from window", () => {
+    process.env.NEXT_PUBLIC_API_URL = "http://127.0.0.1:8080";
+    vi.stubGlobal("window", { location: { origin: "http://localhost:3000" } });
+    expect(isCrossOriginPublicAPI()).toBe(true);
+  });
+});

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,4 +1,6 @@
-import { clearToken, getToken } from "@/lib/auth";
+import { clearSessionMarker } from "@/lib/auth";
+
+const CROSS_ORIGIN_TOKEN_KEY = "portfolio_api_bearer";
 
 /**
  * API base URL for fetches.
@@ -21,16 +23,50 @@ export function apiBaseUrl(): string {
 
 const base = () => apiBaseUrl();
 
+/** True when the configured public API origin differs from the dashboard origin (session cookies are not sent on fetch). */
+export function isCrossOriginPublicAPI(): boolean {
+  if (typeof window === "undefined") return false;
+  const pub = process.env.NEXT_PUBLIC_API_URL?.trim();
+  if (!pub) return false;
+  const u = pub.replace(/\/$/, "");
+  if (!u.startsWith("http://") && !u.startsWith("https://")) return false;
+  try {
+    return new URL(u).origin !== window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+function crossOriginBearer(): string | null {
+  if (typeof window === "undefined") return null;
+  return sessionStorage.getItem(CROSS_ORIGIN_TOKEN_KEY);
+}
+
+export function setCrossOriginBearerToken(token: string) {
+  if (typeof window === "undefined") return;
+  sessionStorage.setItem(CROSS_ORIGIN_TOKEN_KEY, token);
+}
+
+export function clearCrossOriginBearerToken() {
+  if (typeof window === "undefined") return;
+  sessionStorage.removeItem(CROSS_ORIGIN_TOKEN_KEY);
+}
+
 export async function apiFetch(path: string, init: RequestInit = {}) {
   const headers = new Headers(init.headers);
-  const token = getToken();
-  if (token) headers.set("Authorization", `Bearer ${token}`);
+  const bearer = crossOriginBearer();
+  if (bearer) headers.set("Authorization", `Bearer ${bearer}`);
   if (!headers.has("Content-Type") && init.body) {
     headers.set("Content-Type", "application/json");
   }
-  const res = await fetch(`${base()}${path}`, { ...init, headers });
+  const res = await fetch(`${base()}${path}`, {
+    ...init,
+    headers,
+    credentials: "include",
+  });
   if (res.status === 401) {
-    clearToken();
+    clearSessionMarker();
+    clearCrossOriginBearerToken();
     if (typeof window !== "undefined") {
       window.location.href = "/login";
     }

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,17 +1,13 @@
-const COOKIE = "auth_token";
+/** HttpOnly session is set by portfolio-api; this flag only drives middleware (non-secret). */
+const SESSION_FLAG = "session_ok";
 
-export function setToken(token: string) {
+export function markSessionPresent() {
+  if (typeof document === "undefined") return;
   const maxAge = 60 * 60 * 24;
-  document.cookie = `${COOKIE}=${encodeURIComponent(token)}; path=/; max-age=${maxAge}; samesite=lax`;
+  document.cookie = `${SESSION_FLAG}=1; path=/; max-age=${maxAge}; samesite=lax`;
 }
 
-export function getToken(): string | null {
-  if (typeof document === "undefined") return null;
-  const row = document.cookie.split("; ").find((c) => c.startsWith(`${COOKIE}=`));
-  if (!row) return null;
-  return decodeURIComponent(row.slice(COOKIE.length + 1));
-}
-
-export function clearToken() {
-  document.cookie = `${COOKIE}=; path=/; max-age=0`;
+export function clearSessionMarker() {
+  if (typeof document === "undefined") return;
+  document.cookie = `${SESSION_FLAG}=; path=/; max-age=0`;
 }

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -9,8 +9,8 @@ export function middleware(req: NextRequest) {
   if (pathname.startsWith("/login")) {
     return NextResponse.next();
   }
-  const token = req.cookies.get("auth_token")?.value;
-  if (!token) {
+  const hasSession = req.cookies.get("session_ok")?.value === "1";
+  if (!hasSession) {
     const url = req.nextUrl.clone();
     url.pathname = "/login";
     return NextResponse.redirect(url);

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -1,6 +1,15 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const root = path.dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": root,
+    },
+  },
   test: {
     environment: "node",
     include: ["lib/**/*.test.ts"],

--- a/cmd/portfolio-api/main.go
+++ b/cmd/portfolio-api/main.go
@@ -33,6 +33,10 @@ func main() {
 		log.Error("DATABASE_URL is required")
 		os.Exit(1)
 	}
+	if err := config.ValidatePortfolioAPI(cfg); err != nil {
+		log.Error("invalid config", "err", err)
+		os.Exit(1)
+	}
 
 	ctx := context.Background()
 	repo, err := pgstore.New(ctx, cfg.DatabaseURL)
@@ -134,11 +138,45 @@ func (a *app) handleLogin(w http.ResponseWriter, r *http.Request) {
 		Value:    token,
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   r.TLS != nil || isForwardedHTTPS(r),
 		SameSite: http.SameSiteLaxMode,
 		Expires:  exp,
 	})
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(portfolio.LoginResponse{Token: token})
+	resp := portfolio.LoginResponse{}
+	if !looksLikeBrowserLogin(r) {
+		resp.Token = token
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func looksLikeBrowserLogin(r *http.Request) bool {
+	secPurpose := r.Header.Get("Sec-Purpose")
+	if secPurpose == "prefetch" {
+		return false
+	}
+	accept := r.Header.Get("Accept")
+	return strings.Contains(accept, "text/html") || strings.Contains(accept, "*/*")
+}
+
+func isForwardedHTTPS(r *http.Request) bool {
+	if strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
+		return true
+	}
+	if xf := r.Header.Get("Forwarded"); xf != "" {
+		for _, part := range strings.Split(xf, ",") {
+			for _, token := range strings.Split(part, ";") {
+				token = strings.TrimSpace(strings.ToLower(token))
+				if strings.HasPrefix(token, "proto=") {
+					v := strings.Trim(strings.TrimPrefix(token, "proto="), `"`)
+					if v == "https" {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
 }
 
 func (a *app) handleLogout(w http.ResponseWriter, r *http.Request) {
@@ -151,6 +189,7 @@ func (a *app) handleLogout(w http.ResponseWriter, r *http.Request) {
 		Value:    "",
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   r.TLS != nil || isForwardedHTTPS(r),
 		MaxAge:   -1,
 	})
 	w.WriteHeader(http.StatusNoContent)

--- a/cmd/portfolio-api/main_test.go
+++ b/cmd/portfolio-api/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLooksLikeBrowserLogin(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest("POST", "/api/auth/login", nil)
+	r.Header.Set("Accept", "application/json")
+	if looksLikeBrowserLogin(r) {
+		t.Fatal("json accept should not be browser login")
+	}
+	r2 := httptest.NewRequest("POST", "/api/auth/login", nil)
+	r2.Header.Set("Accept", "*/*")
+	if !looksLikeBrowserLogin(r2) {
+		t.Fatal("*/* should be browser login")
+	}
+	r3 := httptest.NewRequest("POST", "/api/auth/login", nil)
+	r3.Header.Set("Accept", "text/html,application/xhtml+xml")
+	if !looksLikeBrowserLogin(r3) {
+		t.Fatal("html accept should be browser login")
+	}
+	r4 := httptest.NewRequest("POST", "/api/auth/login", nil)
+	r4.Header.Set("Accept", "application/json")
+	r4.Header.Set("Sec-Purpose", "prefetch")
+	if looksLikeBrowserLogin(r4) {
+		t.Fatal("prefetch should not omit token heuristic as browser")
+	}
+}
+
+func TestIsForwardedHTTPS(t *testing.T) {
+	t.Parallel()
+	r := httptest.NewRequest("GET", "/", nil)
+	if isForwardedHTTPS(r) {
+		t.Fatal("no headers")
+	}
+	r.Header.Set("X-Forwarded-Proto", "https")
+	if !isForwardedHTTPS(r) {
+		t.Fatal("x-forwarded-proto")
+	}
+	r2 := httptest.NewRequest("GET", "/", nil)
+	r2.Header.Set("Forwarded", `proto=https;host=example.com`)
+	if !isForwardedHTTPS(r2) {
+		t.Fatal("forwarded header")
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"crypto/subtle"
 	"net/http"
 	"strings"
 
@@ -55,14 +56,22 @@ func extractToken(r *http.Request) string {
 }
 
 // InternalKeyMiddleware validates X-Internal-Key for service-to-service routes.
+// key must be non-empty (enforce at process startup); comparison uses constant-time equality when lengths match.
 func InternalKeyMiddleware(key string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Header.Get("X-Internal-Key") != key {
+			if !constantTimeStringEqual(r.Header.Get("X-Internal-Key"), key) {
 				http.Error(w, "forbidden", http.StatusForbidden)
 				return
 			}
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func constantTimeStringEqual(got, want string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
 }

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestInternalKeyMiddleware_rejectsWrongKey(t *testing.T) {
+	t.Parallel()
+	h := InternalKeyMiddleware("correct")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Internal-Key", "wrong")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d", rr.Code)
+	}
+}
+
+func TestInternalKeyMiddleware_acceptsMatchingKey(t *testing.T) {
+	t.Parallel()
+	h := InternalKeyMiddleware("secret-key")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Internal-Key", "secret-key")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusTeapot {
+		t.Fatalf("status = %d", rr.Code)
+	}
+}
+
+func TestConstantTimeStringEqual_lengthMismatch(t *testing.T) {
+	t.Parallel()
+	if constantTimeStringEqual("a", "ab") {
+		t.Fatal("expected false")
+	}
+	if constantTimeStringEqual("ab", "a") {
+		t.Fatal("expected false")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -72,4 +73,12 @@ func getenvDuration(k string, def time.Duration) time.Duration {
 		return def
 	}
 	return d
+}
+
+// ValidatePortfolioAPI returns an error if required secrets are missing or unsafe.
+func ValidatePortfolioAPI(c PortfolioAPI) error {
+	if strings.TrimSpace(c.InternalAPIKey) == "" {
+		return fmt.Errorf("INTERNAL_API_KEY is required and must be non-empty")
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,4 +2,17 @@ package config
 
 import "testing"
 
-func TestPackage(t *testing.T) {}
+func TestValidatePortfolioAPI_requiresInternalKey(t *testing.T) {
+	t.Parallel()
+	err := ValidatePortfolioAPI(PortfolioAPI{InternalAPIKey: ""})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	err = ValidatePortfolioAPI(PortfolioAPI{InternalAPIKey: "   "})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only key")
+	}
+	if ValidatePortfolioAPI(PortfolioAPI{InternalAPIKey: "x"}) != nil {
+		t.Fatal("unexpected error")
+	}
+}

--- a/internal/portfolio/types.go
+++ b/internal/portfolio/types.go
@@ -47,9 +47,10 @@ type LoginRequest struct {
 	Password string `json:"password"`
 }
 
-// LoginResponse returns a bearer token for API clients; browser also gets Set-Cookie.
+// LoginResponse returns a bearer token for non-browser API clients when applicable.
+// Same-origin browser logins omit token and rely on the HttpOnly session cookie only.
 type LoginResponse struct {
-	Token string `json:"token"`
+	Token string `json:"token,omitempty"`
 }
 
 // MapIngestToViews converts ingest snapshot positions into API views.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change targets the high-severity findings from the recent security review.

### portfolio-api

- Refuses to start if `INTERNAL_API_KEY` is missing or whitespace-only, so `/internal/*` is never reachable without a configured secret.
- Validates `X-Internal-Key` with a constant-time comparison when lengths match.
- Omits the session token from the JSON login body for typical browser requests (Accept includes HTML or wildcard); JSON clients that send `Accept: application/json` still receive a bearer token.
- Sets `Secure` on the HttpOnly session cookie when the request is HTTPS or the connection is TLS-terminated (`X-Forwarded-Proto` / `Forwarded`).

### Dashboard

- Stops putting the session token in a JavaScript-readable cookie.
- Uses `credentials: "include"` for API calls so the HttpOnly `session` cookie is sent on same-origin `/api-go` rewrites.
- Uses a non-secret `session_ok` cookie only for middleware routing after login.
- When `NEXT_PUBLIC_API_URL` points at another origin, stores the bearer token in `sessionStorage` and sends `Authorization` (Lax cookies are not sent on that cross-site pattern).

### Other

- Vitest config: resolve `@` alias for unit tests.
- `.env.example`: clarifies that `INTERNAL_API_KEY` is required.

## Verification

- `go test ./cmd/... ./internal/...`
- `npm test` and `npm run lint` in `apps/web`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48ebb461-2070-4124-82f2-c902566e57ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48ebb461-2070-4124-82f2-c902566e57ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

