### PR TITLE
fix(ci): golangci-lint 1.61 config — replace run.skip-dirs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,10 @@
 run:
   timeout: 5m
-  skip-dirs:
+
+issues:
+  exclude-dirs:
     - apps/web/node_modules
+
 linters:
   enable:
     - errcheck


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`golangci-lint config verify` fails on v1.61 because `run.skip-dirs` is no longer allowed in the JSON schema (`additionalProperties 'skip-dirs' not allowed`).

## Change

- Move the directory exclusion from `run.skip-dirs` to `issues.exclude-dirs` (supported replacement in current golangci-lint).

Verified locally with golangci-lint **v1.61.0**: `golangci-lint config verify` succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48ebb461-2070-4124-82f2-c902566e57ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48ebb461-2070-4124-82f2-c902566e57ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

