### PR TITLE
ci: balanced free security checks (OSV PR, go mod verify, Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      golang-patch:
+        patterns:
+          - "*"
+        update-types:
+          - patch
+
+  - package-ecosystem: npm
+    directory: /apps/web
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,0 +1,18 @@
+# OSV.dev: compares base vs PR; fails only on newly introduced vulns (balanced for existing debt).
+# SARIF upload needs default GITHUB_TOKEN with security-events: write (public repos: OK).
+name: OSV-Scanner PR
+
+on:
+  pull_request:
+    branches: [main, phase-1]
+  merge_group:
+    branches: [main, phase-1]
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan-pr:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,32 @@
+# Balanced, free security checks for PRs:
+# - go mod verify: module graph / sum integrity
+# - OSV-Scanner: see osv-scanner-pr.yml (diff vs base for go.sum + package-lock.json)
+# - Dependabot: see .github/dependabot.yml
+#
+# npm audit is omitted here: Next.js currently reports critical advisories in-range;
+# OSV PR diff + Dependabot handle JS supply chain without blocking every PR on noise.
+#
+# Tip: run `govulncheck ./...` locally after bumping the Go toolchain; older stdlib
+# versions can report many fixed-in-newer-Go advisories that are not practical as CI gates.
+name: Security
+
+on:
+  push:
+    branches: [main, phase-1]
+  pull_request:
+    branches: [main, phase-1]
+
+permissions:
+  contents: read
+
+jobs:
+  go-mod-verify:
+    name: go mod verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3e937a0e878d5e94f57d5040d34cfbb7a # v4.1.7
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: "1.23"
+          cache-dependency-path: go.sum
+      - run: go mod verify

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,8 +24,8 @@ jobs:
     name: go mod verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3e937a0e878d5e94f57d5040d34cfbb7a # v4.1.7
-      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.23"
           cache-dependency-path: go.sum


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this adds

### 1. `.github/workflows/security.yml`
- Runs on **push** and **pull_request** to **`main`** and **`phase-1`**.
- **`go mod verify`** — integrity of `go.sum` / module graph (cheap, deterministic).

### 2. `.github/workflows/osv-scanner-pr.yml`
- Google **OSV-Scanner** reusable **PR** workflow (`v2.3.5`).
- Compares vulnerability state **base vs PR** and fails only when **new** issues are introduced (good balance vs. legacy debt).
- Triggers on **PR** and **merge_group** to `main` / `phase-1`.
- Uses `security-events: write` for SARIF upload to **Security → Code scanning** (works on public repos; private orgs may need GHAS).

### 3. `.github/dependabot.yml`
- **gomod** (root): weekly, patch updates grouped.
- **npm** (`apps/web`): weekly.
- **github-actions**: weekly (keeps action pins fresher).

## Intentionally omitted (for “balanced”)
- **`npm audit` in CI** — current `next` reports **critical** in-range advisories; it would block unrelated PRs. OSV PR diff + Dependabot cover JS supply chain without that noise.
- **`govulncheck` in CI** — on Go 1.23 it surfaces many **stdlib** advisories fixed only in newer toolchains; better run locally after a Go bump than as a red-always gate.

## Follow-up (optional)
- Tighten Dependabot grouping for npm once Next is on a patched line.
- Add `govulncheck` after upgrading Go in CI/Dockerfile to a current patch release.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48ebb461-2070-4124-82f2-c902566e57ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48ebb461-2070-4124-82f2-c902566e57ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

