### PR TITLE
fix(ci): golangci-lint 1.61 config and staticcheck in logger tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,10 @@
 run:
   timeout: 5m
-  skip-dirs:
+
+issues:
+  exclude-dirs:
     - apps/web/node_modules
+
 linters:
   enable:
     - errcheck

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -80,7 +81,7 @@ func TestNewLogger_invalidLevelFallbackAndStderr(t *testing.T) {
 		t.Fatalf("expected stderr warning, got %q", errBuf.String())
 	}
 	// Fallback info: debug should not appear
-	if log.Enabled(nil, slog.LevelDebug) {
+	if log.Enabled(context.TODO(), slog.LevelDebug) {
 		t.Fatal("expected info level")
 	}
 	log.Info("ok")
@@ -94,7 +95,7 @@ func TestNewLogger_invalidLevelFallbackAndStderr(t *testing.T) {
 func TestNewLogger_debugLevel(t *testing.T) {
 	var out bytes.Buffer
 	log := newLogger("svc", "debug", "", &out, io.Discard)
-	if !log.Enabled(nil, slog.LevelDebug) {
+	if !log.Enabled(context.TODO(), slog.LevelDebug) {
 		t.Fatal("expected debug enabled")
 	}
 	log.Debug("trace")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fixes

1. **`.golangci.yml`** — Replace deprecated `run.skip-dirs` with `issues.exclude-dirs` so `golangci-lint config verify` passes on **v1.61.0** (required by CI).

2. **`internal/logging/logger_test.go`** — Replace `log.Enabled(nil, …)` with `log.Enabled(context.TODO(), …)` to satisfy **staticcheck SA1012**.

## Verification

- `go test ./internal/logging/...`
- `golangci-lint config verify` and `golangci-lint run ./...` with v1.61.0
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48ebb461-2070-4124-82f2-c902566e57ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48ebb461-2070-4124-82f2-c902566e57ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

