### PR TITLE
docs: add architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,36 @@ US equities portfolio tracker — Go services + Next.js dashboard, connected to 
 - **DB**: Postgres 16
 - **Infra**: Docker Compose
 
+## Architecture
+
+Services run on a shared Docker network (`portfolio-net`). The dashboard talks to the portfolio API; ingest and signals use the internal API key to call the API. Ingest pulls market and account data from IB Gateway (or a mock when `IBKR_MODE=mock`).
+
+```mermaid
+flowchart TB
+  subgraph Clients
+    B[Browser]
+  end
+
+  subgraph Compose["Docker Compose"]
+    W[web<br/>Next.js :3000]
+    API[portfolio-api<br/>Go :8080]
+    DB[(Postgres :5432)]
+    ING[ingest<br/>Go]
+    SIG[signals<br/>Go]
+    IB[ib-gateway<br/>stub / TWS]
+  end
+
+  DC[Discord]
+
+  B -->|session / dashboard| W
+  W -->|HTTP API| API
+  API --> DB
+  ING -->|IBKR| IB
+  ING -->|internal snapshots| API
+  SIG -->|internal reads| API
+  SIG -.->|optional webhook| DC
+```
+
 ## Local development
 
 1. `cp .env.example .env` and set at least `DATABASE_URL`, `INTERNAL_API_KEY`, and optional `DISCORD_WEBHOOK_URL`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a Mermaid flowchart to the README showing how the Next.js web app, Go services (portfolio-api, ingest, signals), Postgres, IB Gateway, and optional Discord fit together on the Docker Compose network. A short paragraph explains the internal API and mock gateway behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83e29b09-13be-4c25-92c5-d585eee96861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83e29b09-13be-4c25-92c5-d585eee96861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

