### PR TITLE
CB-02/CB-04: canonical broker domain models and multi-provider broker config

### DIFF
--- a/.board/milestones/coinbase/EXECUTION_PLAN.md
+++ b/.board/milestones/coinbase/EXECUTION_PLAN.md
@@ -36,11 +36,11 @@ CB-01 → CB-02 → CB-06 → CB-07 → CB-09 → CB-10 → CB-12 → CB-13 → 
 | Ticket | Status | Owner role | Last update (UTC) | Notes |
 |---|---|---|---|---|
 | CB-01 | done | implementer/tester/reviewer | 2026-05-02T05:05:18Z | Completed and committed |
-| CB-02 | in_progress | planner | 2026-05-02T05:05:18Z | Ready after CB-01 completion |
-| CB-03 | todo | planner | 2026-05-02T00:00:00Z | Waits on CB-01, CB-02 |
-| CB-04 | in_progress | planner | 2026-05-02T05:05:18Z | Ready after CB-01 completion |
+| CB-02 | done | implementer/tester/reviewer | 2026-05-02T05:47:48Z | Domain models + tests complete |
+| CB-03 | in_progress | planner | 2026-05-02T05:47:48Z | Ready after CB-02 |
+| CB-04 | done | implementer/tester/reviewer | 2026-05-02T05:47:48Z | Broker config redesign complete |
 | CB-05 | todo | planner | 2026-05-02T00:00:00Z | Waits on CB-02, CB-03 |
-| CB-06 | todo | planner | 2026-05-02T00:00:00Z | Waits on CB-02 |
+| CB-06 | in_progress | planner | 2026-05-02T05:47:48Z | Ready after CB-02 |
 | CB-07 | todo | planner | 2026-05-02T00:00:00Z | Waits on CB-04, CB-06 |
 | CB-08 | todo | planner | 2026-05-02T00:00:00Z | Waits on CB-02, CB-07 |
 | CB-09 | todo | planner | 2026-05-02T00:00:00Z | Waits on CB-06, CB-07 |

--- a/.board/milestones/coinbase/PROGRESS_LOG.md
+++ b/.board/milestones/coinbase/PROGRESS_LOG.md
@@ -44,3 +44,17 @@
 - Next actions:
   - Commit CB-01 with ticket-formatted message.
   - Start CB-02 + CB-04 planning briefs.
+
+
+## 2026-05-02T05:47:48Z — Iteration 3 (CB-02 + CB-04 complete)
+- Attempted:
+  - Implemented canonical broker domain types for instrument/money/quantity/fill with normalization + decimal validation.
+  - Implemented broker config redesign in `internal/config` with `BROKER_PROVIDER` / `BROKER_ENV` and Coinbase read/trade env split.
+  - Wired ingest startup to load/validate broker config via config package and map into brokerwire legacy config.
+- Acceptance criteria evidence:
+  - CB-02: decimal-safe string-backed amount/quantity constructors using rational parsing; normalization behavior + tests.
+  - CB-04: config package owns new vars, provider-aware startup validation, `.env.example` and README updated.
+- Tests:
+  - `go test ./internal/broker ./internal/config ./internal/brokerwire ./cmd/ingest` ✅ pass
+- Next actions:
+  - Begin CB-03 and CB-06 (wave 3) in parallel tracks.

--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,21 @@ POSTGRES_PASSWORD=changeme
 POSTGRES_DB=portfolio
 DATABASE_URL=postgres://portfolio:changeme@db:5432/portfolio?sslmode=disable
 
-# IBKR (use IBKR_MODE=paper or live when a real gateway is available)
+# Broker selection
+BROKER_PROVIDER=ibkr
+BROKER_ENV=paper
+
+# IBKR (used when BROKER_PROVIDER=ibkr; use IBKR_MODE=paper or live when a real gateway is available)
 IBKR_GATEWAY_HOST=ib-gateway
 IBKR_GATEWAY_PORT=4001
 IBKR_MODE=mock
 
+
+# Coinbase (used when BROKER_PROVIDER=coinbase)
+COINBASE_READ_API_KEY=
+COINBASE_READ_API_SECRET=
+COINBASE_TRADE_API_KEY=
+COINBASE_TRADE_API_SECRET=
 # Auth (portfolio-api)
 AUTH_USERNAME=admin
 AUTH_PASSWORD=changeme

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ flowchart TB
 
 ### IB Gateway
 
-- For development without a live gateway, set `IBKR_MODE=mock` (used by `ingest`).
+- Select provider with `BROKER_PROVIDER` (`ibkr` default, `coinbase` reserved for follow-up work).
+- For IBKR development without a live gateway, set `IBKR_MODE=mock` (used by `ingest`).
 - With IB Gateway on the host (not in Docker), set `IBKR_GATEWAY_HOST=host.docker.internal` and configure Client Portal / TWS ports per [internal/broker/ibkr/DECISION.md](internal/broker/ibkr/DECISION.md).
 
 ### Stylekit (dashboard)

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/schtvr/morgans-d-stonks/internal/broker"
 	"github.com/schtvr/morgans-d-stonks/internal/brokerwire"
+	"github.com/schtvr/morgans-d-stonks/internal/config"
 	"github.com/schtvr/morgans-d-stonks/internal/ingest"
 	"github.com/schtvr/morgans-d-stonks/internal/logging"
 )
@@ -14,8 +14,12 @@ import (
 func main() {
 	log := logging.New("ingest")
 
-	cfg := broker.LoadConfigFromEnv()
-	br, err := brokerwire.New(cfg)
+	brokerCfg := config.LoadBroker()
+	if err := brokerCfg.Validate(); err != nil {
+		log.Error("broker-config", "err", err)
+		os.Exit(1)
+	}
+	br, err := brokerwire.New(brokerCfg.ToLegacyBrokerConfig())
 	if err != nil {
 		log.Error("broker", "err", err)
 		os.Exit(1)

--- a/internal/broker/config.go
+++ b/internal/broker/config.go
@@ -7,7 +7,9 @@ import (
 
 // Config configures broker construction (IBKR / mock).
 type Config struct {
-	Mode        string // mock | paper | live
+	Provider    string // ibkr | coinbase
+	Environment string // paper | live
+	Mode        string // ibkr-only: mock | paper | live
 	GatewayHost string
 	GatewayPort int
 	// PortalPort is the HTTPS Client Portal port (typically 5000). 0 means unset.
@@ -17,6 +19,8 @@ type Config struct {
 // LoadConfigFromEnv reads IBKR_* environment variables.
 func LoadConfigFromEnv() Config {
 	cfg := Config{
+		Provider:    getenv("BROKER_PROVIDER", "ibkr"),
+		Environment: getenv("BROKER_ENV", "paper"),
 		Mode:        getenv("IBKR_MODE", "mock"),
 		GatewayHost: getenv("IBKR_GATEWAY_HOST", "127.0.0.1"),
 		GatewayPort: getenvInt("IBKR_GATEWAY_PORT", 4001),

--- a/internal/broker/domain.go
+++ b/internal/broker/domain.go
@@ -1,0 +1,62 @@
+package broker
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// Instrument is a provider-agnostic tradable identifier.
+type Instrument struct {
+	Symbol string
+	Venue  string
+}
+
+// Money is a fixed-precision decimal amount in a currency.
+type Money struct {
+	Amount   string
+	Currency string
+}
+
+// Quantity is a fixed-precision decimal quantity.
+type Quantity struct {
+	Value string
+}
+
+// Fill is a provider-agnostic execution fill.
+type Fill struct {
+	OrderID   string
+	Quantity  Quantity
+	Price     Money
+	Liquidity string
+}
+
+// NormalizeInstrument applies canonical symbol/venue formatting.
+func NormalizeInstrument(symbol, venue string) Instrument {
+	s := strings.ToUpper(strings.TrimSpace(symbol))
+	v := strings.ToUpper(strings.TrimSpace(venue))
+	if v == "" {
+		v = "SMART"
+	}
+	return Instrument{Symbol: s, Venue: v}
+}
+
+// NewMoney creates decimal-safe money.
+func NewMoney(amount, currency string) (Money, error) {
+	if _, ok := new(big.Rat).SetString(strings.TrimSpace(amount)); !ok {
+		return Money{}, fmt.Errorf("invalid money amount %q", amount)
+	}
+	c := strings.ToUpper(strings.TrimSpace(currency))
+	if c == "" {
+		return Money{}, fmt.Errorf("currency is required")
+	}
+	return Money{Amount: strings.TrimSpace(amount), Currency: c}, nil
+}
+
+// NewQuantity creates decimal-safe quantity.
+func NewQuantity(value string) (Quantity, error) {
+	if _, ok := new(big.Rat).SetString(strings.TrimSpace(value)); !ok {
+		return Quantity{}, fmt.Errorf("invalid quantity %q", value)
+	}
+	return Quantity{Value: strings.TrimSpace(value)}, nil
+}

--- a/internal/broker/domain_test.go
+++ b/internal/broker/domain_test.go
@@ -1,0 +1,25 @@
+package broker
+
+import "testing"
+
+func TestNormalizeInstrument(t *testing.T) {
+	got := NormalizeInstrument(" aapl ", " ")
+	if got.Symbol != "AAPL" || got.Venue != "SMART" {
+		t.Fatalf("unexpected normalization: %+v", got)
+	}
+}
+
+func TestMoneyAndQuantityDecimalValidation(t *testing.T) {
+	if _, err := NewMoney("100.1234", "usd"); err != nil {
+		t.Fatalf("expected valid money: %v", err)
+	}
+	if _, err := NewQuantity("0.0005"); err != nil {
+		t.Fatalf("expected valid quantity: %v", err)
+	}
+	if _, err := NewMoney("nope", "USD"); err == nil {
+		t.Fatal("expected invalid money error")
+	}
+	if _, err := NewQuantity("nanx"); err == nil {
+		t.Fatal("expected invalid quantity error")
+	}
+}

--- a/internal/brokerwire/wire.go
+++ b/internal/brokerwire/wire.go
@@ -11,13 +11,24 @@ import (
 
 // New returns a read broker based on cfg.Mode.
 func New(cfg broker.Config) (broker.Broker, error) {
-	switch cfg.Mode {
-	case "mock":
-		return mock.New(), nil
-	case "paper", "live":
-		return ibkr.New(cfg)
+	switch cfg.Provider {
+	case "":
+		cfg.Provider = "ibkr"
+	}
+	switch cfg.Provider {
+	case "ibkr":
+		switch cfg.Mode {
+		case "mock":
+			return mock.New(), nil
+		case "paper", "live":
+			return ibkr.New(cfg)
+		default:
+			return nil, fmt.Errorf("brokerwire: unknown IBKR_MODE %q", cfg.Mode)
+		}
+	case "coinbase":
+		return nil, fmt.Errorf("brokerwire: provider %q not implemented yet", cfg.Provider)
 	default:
-		return nil, fmt.Errorf("brokerwire: unknown IBKR_MODE %q", cfg.Mode)
+		return nil, fmt.Errorf("brokerwire: unknown BROKER_PROVIDER %q", cfg.Provider)
 	}
 }
 

--- a/internal/config/broker.go
+++ b/internal/config/broker.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/schtvr/morgans-d-stonks/internal/broker"
+)
+
+// Broker config supports provider selection and permission-separated credentials.
+type Broker struct {
+	Provider string
+	Env      string
+
+	IBKRMode        string
+	IBKRGatewayHost string
+	IBKRGatewayPort int
+	IBKRPortalPort  int
+
+	CoinbaseReadAPIKey     string
+	CoinbaseReadAPISecret  string
+	CoinbaseTradeAPIKey    string
+	CoinbaseTradeAPISecret string
+}
+
+func LoadBroker() Broker {
+	return Broker{
+		Provider:               getenv("BROKER_PROVIDER", "ibkr"),
+		Env:                    getenv("BROKER_ENV", "paper"),
+		IBKRMode:               getenv("IBKR_MODE", "mock"),
+		IBKRGatewayHost:        getenv("IBKR_GATEWAY_HOST", "127.0.0.1"),
+		IBKRGatewayPort:        getenvInt("IBKR_GATEWAY_PORT", 4001),
+		IBKRPortalPort:         getenvInt("IBKR_CLIENT_PORTAL_PORT", 5000),
+		CoinbaseReadAPIKey:     getenv("COINBASE_READ_API_KEY", ""),
+		CoinbaseReadAPISecret:  getenv("COINBASE_READ_API_SECRET", ""),
+		CoinbaseTradeAPIKey:    getenv("COINBASE_TRADE_API_KEY", ""),
+		CoinbaseTradeAPISecret: getenv("COINBASE_TRADE_API_SECRET", ""),
+	}
+}
+
+func (c Broker) Validate() error {
+	p := strings.ToLower(strings.TrimSpace(c.Provider))
+	switch p {
+	case "ibkr":
+		if c.IBKRGatewayHost == "" {
+			return fmt.Errorf("IBKR_GATEWAY_HOST is required for provider=ibkr")
+		}
+	case "coinbase":
+		if strings.TrimSpace(c.CoinbaseReadAPIKey) == "" || strings.TrimSpace(c.CoinbaseReadAPISecret) == "" {
+			return fmt.Errorf("COINBASE_READ_API_KEY and COINBASE_READ_API_SECRET are required for provider=coinbase")
+		}
+	default:
+		return fmt.Errorf("unknown BROKER_PROVIDER %q", c.Provider)
+	}
+	return nil
+}
+
+func (c Broker) ToLegacyBrokerConfig() broker.Config {
+	return broker.Config{
+		Provider:    strings.ToLower(c.Provider),
+		Environment: strings.ToLower(c.Env),
+		Mode:        c.IBKRMode,
+		GatewayHost: c.IBKRGatewayHost,
+		GatewayPort: c.IBKRGatewayPort,
+		PortalPort:  c.IBKRPortalPort,
+	}
+}
+
+func getenvInt(k string, def int) int {
+	v := os.Getenv(k)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}

--- a/internal/config/broker_test.go
+++ b/internal/config/broker_test.go
@@ -1,0 +1,15 @@
+package config
+
+import "testing"
+
+func TestBrokerValidate(t *testing.T) {
+	if err := (Broker{Provider: "bad"}).Validate(); err == nil {
+		t.Fatal("expected unknown provider error")
+	}
+	if err := (Broker{Provider: "coinbase"}).Validate(); err == nil {
+		t.Fatal("expected missing coinbase creds error")
+	}
+	if err := (Broker{Provider: "coinbase", CoinbaseReadAPIKey: "k", CoinbaseReadAPISecret: "s"}).Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a canonical, provider-agnostic domain for broker concepts (instrument, money, quantity, fills) so downstream code and future providers (Coinbase) can use stable types.
- Introduce a provider-aware broker configuration surface to support multiple providers (`BROKER_PROVIDER`) and separate read/trade credentials for Coinbase without changing business logic access patterns.
- Preserve existing IBKR behavior and backward compatibility while surfacing clear errors for not-yet-implemented providers during wiring.

### Description
- Added canonical broker domain types and helpers in `internal/broker/domain.go` with `Instrument`, `Money`, `Quantity`, `Fill`, `NormalizeInstrument`, `NewMoney`, and `NewQuantity`, and unit tests in `internal/broker/domain_test.go` to validate normalization and decimal parsing.
- Introduced `internal/config/broker.go` implementing `LoadBroker()`, provider-aware `Validate()`, and `ToLegacyBrokerConfig()` that maps the new `Broker` config into the existing `broker.Config` used by the wiring layer, plus tests in `internal/config/broker_test.go`.
- Extended `internal/broker/config.go` and `internal/brokerwire/wire.go` to include `Provider`/`Environment` handling; `brokerwire.New` now switches by provider and preserves existing IBKR `Mode` handling while returning a clear "not implemented yet" error path for `coinbase`.
- Updated `cmd/ingest/main.go` to load and validate the new broker config via `config.LoadBroker()` before creating the broker, and updated `.env.example`, `README.md`, and Coinbase milestone docs to reflect the new env vars and task status.

### Testing
- Ran formatting: `gofmt -w` on modified files (succeeded).
- Ran unit tests: `go test ./internal/broker ./internal/config ./internal/brokerwire ./cmd/ingest` and all tests passed.
- Verified ingest binary compiles under the new config wiring (package build/tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58f1e17948329be332bf0730043c8)