### PR TITLE
CB-03: implement Coinbase read-only adapter and metadata cache

### DIFF
--- a/.board/milestones/coinbase/EXECUTION_PLAN.md
+++ b/.board/milestones/coinbase/EXECUTION_PLAN.md
@@ -37,7 +37,7 @@ CB-01 → CB-02 → CB-06 → CB-07 → CB-09 → CB-10 → CB-12 → CB-13 → 
 |---|---|---|---|---|
 | CB-01 | done | implementer/tester/reviewer | 2026-05-02T05:05:18Z | Completed and committed |
 | CB-02 | done | implementer/tester/reviewer | 2026-05-02T05:47:48Z | Domain models + tests complete |
-| CB-03 | in_progress | planner | 2026-05-02T05:47:48Z | Ready after CB-02 |
+| CB-03 | done | implementer/tester/reviewer | 2026-05-04T00:00:00Z | Coinbase read adapter + metadata cache complete |
 | CB-04 | done | implementer/tester/reviewer | 2026-05-02T05:47:48Z | Broker config redesign complete |
 | CB-05 | todo | planner | 2026-05-02T00:00:00Z | Waits on CB-02, CB-03 |
 | CB-06 | in_progress | planner | 2026-05-02T05:47:48Z | Ready after CB-02 |

--- a/.board/milestones/coinbase/PROGRESS_LOG.md
+++ b/.board/milestones/coinbase/PROGRESS_LOG.md
@@ -58,3 +58,19 @@
   - `go test ./internal/broker ./internal/config ./internal/brokerwire ./cmd/ingest` ✅ pass
 - Next actions:
   - Begin CB-03 and CB-06 (wave 3) in parallel tracks.
+
+## 2026-05-04T00:00:00Z — Iteration 4 (CB-03 complete)
+- Attempted:
+  - Implemented Coinbase read-only broker adapter with positions/summary/quotes methods.
+  - Added retry/backoff behavior for 429/5xx responses with context-aware cancellation.
+  - Added product metadata cache keyed by product id and quote normalization helper.
+  - Wired broker factory to return Coinbase adapter for `BROKER_PROVIDER=coinbase`.
+- Acceptance criteria evidence (CB-03):
+  - [x] Broker read interface implemented.
+  - [x] Retries/backoff on 429/5xx with context timeouts.
+  - [x] Product metadata cache (tick/min size/status).
+  - [x] Integration-style test with mocked Coinbase API server.
+- Tests:
+  - `go test ./internal/broker/... ./internal/brokerwire` ✅ pass
+- Next actions:
+  - Start CB-06 persistence schema implementation.

--- a/internal/broker/coinbase/client.go
+++ b/internal/broker/coinbase/client.go
@@ -1,0 +1,194 @@
+package coinbase
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/schtvr/morgans-d-stonks/internal/broker"
+)
+
+const defaultBaseURL = "https://api.coinbase.com"
+
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+
+	mu    sync.RWMutex
+	cache map[string]ProductMetadata
+}
+
+type ProductMetadata struct {
+	ProductID       string
+	BaseIncrement   float64
+	QuoteIncrement  float64
+	TradingDisabled bool
+}
+
+func NewReadOnly(httpClient *http.Client, baseURL string) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = defaultBaseURL
+	}
+	return &Client{httpClient: httpClient, baseURL: strings.TrimRight(baseURL, "/"), cache: map[string]ProductMetadata{}}
+}
+
+func (c *Client) Capabilities() map[broker.Capability]bool {
+	return map[broker.Capability]bool{broker.CapabilityReadPositions: true, broker.CapabilityReadSummary: true, broker.CapabilityQuote: true}
+}
+func (c *Client) Close() error                                   { return nil }
+func (c *Client) IsMarketOpen(ctx context.Context) (bool, error) { return true, nil }
+
+func (c *Client) Positions(ctx context.Context) ([]broker.Position, error) {
+	var resp struct {
+		Accounts []struct {
+			Currency         string `json:"currency"`
+			AvailableBalance string `json:"available_balance"`
+		} `json:"accounts"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/v2/accounts", nil, &resp); err != nil {
+		return nil, err
+	}
+	out := make([]broker.Position, 0, len(resp.Accounts))
+	now := time.Now().UTC()
+	for _, a := range resp.Accounts {
+		q, _ := strconv.ParseFloat(a.AvailableBalance, 64)
+		if q == 0 {
+			continue
+		}
+		out = append(out, broker.Position{Symbol: strings.ToUpper(a.Currency) + "-USD", Quantity: q, Currency: "USD", UpdatedAt: now})
+	}
+	return out, nil
+}
+
+func (c *Client) AccountSummary(ctx context.Context) (*broker.AccountSummary, error) {
+	positions, err := c.Positions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	net := 0.0
+	for _, p := range positions {
+		net += p.MarketValue
+	}
+	return &broker.AccountSummary{AccountID: "coinbase", NetLiquidation: net, TotalCash: net, BuyingPower: net, Currency: "USD", UpdatedAt: time.Now().UTC()}, nil
+}
+
+func (c *Client) Quotes(ctx context.Context, symbols []string) ([]broker.Quote, error) {
+	quotes := make([]broker.Quote, 0, len(symbols))
+	for _, s := range symbols {
+		productID := normalizeProductID(s)
+		if err := c.ensureProductCached(ctx, productID); err != nil {
+			return nil, err
+		}
+		var body struct {
+			Data struct {
+				Amount string `json:"amount"`
+			} `json:"data"`
+		}
+		if err := c.doJSON(ctx, http.MethodGet, "/v2/prices/"+url.PathEscape(productID)+"/spot", nil, &body); err != nil {
+			return nil, err
+		}
+		last, _ := strconv.ParseFloat(body.Data.Amount, 64)
+		quotes = append(quotes, broker.Quote{Symbol: productID, Last: last, Bid: last, Ask: last, UpdatedAt: time.Now().UTC()})
+	}
+	return quotes, nil
+}
+
+func normalizeProductID(symbol string) string {
+	s := strings.ToUpper(strings.TrimSpace(symbol))
+	if strings.Contains(s, "-") {
+		return s
+	}
+	return s + "-USD"
+}
+
+func (c *Client) ensureProductCached(ctx context.Context, productID string) error {
+	c.mu.RLock()
+	_, ok := c.cache[productID]
+	c.mu.RUnlock()
+	if ok {
+		return nil
+	}
+	var resp struct {
+		Products []struct {
+			ProductID       string `json:"product_id"`
+			BaseIncrement   string `json:"base_increment"`
+			QuoteIncrement  string `json:"quote_increment"`
+			TradingDisabled bool   `json:"trading_disabled"`
+		} `json:"products"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/api/v3/brokerage/products", nil, &resp); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, p := range resp.Products {
+		bi := parseStep(p.BaseIncrement)
+		qi := parseStep(p.QuoteIncrement)
+		c.cache[strings.ToUpper(p.ProductID)] = ProductMetadata{ProductID: strings.ToUpper(p.ProductID), BaseIncrement: bi, QuoteIncrement: qi, TradingDisabled: p.TradingDisabled}
+	}
+	return nil
+}
+
+func parseStep(v string) float64 {
+	f, _ := strconv.ParseFloat(v, 64)
+	if f <= 0 {
+		return 0
+	}
+	return math.Abs(f)
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path string, body io.Reader, dst any) error {
+	endpoint := c.baseURL + path
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+		if err != nil {
+			return fmt.Errorf("coinbase: build request %s: %w", path, err)
+		}
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		func() {
+			defer resp.Body.Close()
+			if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+				lastErr = fmt.Errorf("coinbase: %s status %d", path, resp.StatusCode)
+				return
+			}
+			if resp.StatusCode >= 400 {
+				b, _ := io.ReadAll(resp.Body)
+				lastErr = fmt.Errorf("coinbase: %s status %d: %s", path, resp.StatusCode, strings.TrimSpace(string(b)))
+				return
+			}
+			if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+				lastErr = fmt.Errorf("coinbase: decode %s: %w", path, err)
+				return
+			}
+			lastErr = nil
+		}()
+		if lastErr == nil {
+			return nil
+		}
+		if resp != nil && !(resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt+1) * 100 * time.Millisecond):
+		}
+	}
+	return lastErr
+}

--- a/internal/broker/coinbase/client_test.go
+++ b/internal/broker/coinbase/client_test.go
@@ -1,0 +1,53 @@
+package coinbase
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestQuotesRetryAndCache(t *testing.T) {
+	var productsHits int32
+	var spotHits int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/brokerage/products":
+			atomic.AddInt32(&productsHits, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"products":[{"product_id":"BTC-USD","base_increment":"0.00000001","quote_increment":"0.01","trading_disabled":false}]}`))
+		case "/v2/prices/BTC-USD/spot":
+			n := atomic.AddInt32(&spotHits, 1)
+			if n == 1 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"amount":"65000.12"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewReadOnly(ts.Client(), ts.URL)
+	ctx := context.Background()
+	quotes, err := c.Quotes(ctx, []string{"BTC"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(quotes) != 1 || quotes[0].Symbol != "BTC-USD" {
+		t.Fatalf("unexpected quotes: %+v", quotes)
+	}
+	_, err = c.Quotes(ctx, []string{"BTC-USD"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if atomic.LoadInt32(&productsHits) != 1 {
+		t.Fatalf("expected cached products call once, got %d", productsHits)
+	}
+	if atomic.LoadInt32(&spotHits) < 2 {
+		t.Fatalf("expected spot retries, got %d", spotHits)
+	}
+}

--- a/internal/brokerwire/wire.go
+++ b/internal/brokerwire/wire.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/schtvr/morgans-d-stonks/internal/broker"
+	"github.com/schtvr/morgans-d-stonks/internal/broker/coinbase"
 	"github.com/schtvr/morgans-d-stonks/internal/broker/ibkr"
 	"github.com/schtvr/morgans-d-stonks/internal/broker/mock"
 )
@@ -26,7 +27,7 @@ func New(cfg broker.Config) (broker.Broker, error) {
 			return nil, fmt.Errorf("brokerwire: unknown IBKR_MODE %q", cfg.Mode)
 		}
 	case "coinbase":
-		return nil, fmt.Errorf("brokerwire: provider %q not implemented yet", cfg.Provider)
+		return coinbase.NewReadOnly(nil, ""), nil
 	default:
 		return nil, fmt.Errorf("brokerwire: unknown BROKER_PROVIDER %q", cfg.Provider)
 	}

--- a/internal/brokerwire/wire_test.go
+++ b/internal/brokerwire/wire_test.go
@@ -26,3 +26,13 @@ func TestNewExecutionUnsupportedMode(t *testing.T) {
 		t.Fatal("expected unsupported execution error")
 	}
 }
+
+func TestNewCoinbase(t *testing.T) {
+	b, err := New(broker.Config{Provider: "coinbase"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !broker.HasCapability(b, broker.CapabilityQuote) {
+		t.Fatal("expected coinbase quote capability")
+	}
+}


### PR DESCRIPTION
### Motivation
- Progress the Coinbase milestone by adding a read-only broker adapter so the system can fetch positions, account summaries, and quotes from Coinbase for follow-up features. 
- Provide robust network behavior and local product metadata to meet acceptance criteria for retries/backoff and product tick/size caching.

### Description
- Add a new read-only Coinbase adapter at `internal/broker/coinbase` implementing the `broker.ReadBroker` surface with `Positions`, `AccountSummary`, and `Quotes` methods and symbol normalization via `normalizeProductID`.
- Implement a product metadata cache (`ensureProductCached`) and parsing helpers (`parseStep`) to store tick/quote increments and trading status in memory for reuse.
- Add resilient HTTP JSON helper `doJSON` with retry/backoff for `429` and `5xx` responses and context-aware cancellation.
- Wire `BROKER_PROVIDER=coinbase` to return the Coinbase read adapter in `internal/brokerwire.New`, add `TestNewCoinbase`, and add an integration-style test `internal/broker/coinbase/client_test.go` using `httptest` to validate retry and cache behavior; update milestone docs to mark CB-03 done.

### Testing
- Ran `go test ./internal/broker/... ./internal/brokerwire` which executed unit and integration-style tests and completed successfully. 
- The new `internal/broker/coinbase` tests exercise `Quotes` retry on `429` and product metadata caching via an `httptest` server and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7fad4e7448329adf0b1ff0da3bcff)