### PR TITLE
SCH-23: compute Coinbase position market values

### DIFF
--- a/internal/broker/coinbase/client.go
+++ b/internal/broker/coinbase/client.go
@@ -61,12 +61,36 @@ func (c *Client) Positions(ctx context.Context) ([]broker.Position, error) {
 	}
 	out := make([]broker.Position, 0, len(resp.Accounts))
 	now := time.Now().UTC()
+	symbols := make([]string, 0, len(resp.Accounts))
 	for _, a := range resp.Accounts {
 		q, _ := strconv.ParseFloat(a.AvailableBalance, 64)
 		if q == 0 {
 			continue
 		}
-		out = append(out, broker.Position{Symbol: strings.ToUpper(a.Currency) + "-USD", Quantity: q, Currency: "USD", UpdatedAt: now})
+		symbol := strings.ToUpper(a.Currency) + "-USD"
+		out = append(out, broker.Position{Symbol: symbol, Quantity: q, Currency: "USD", UpdatedAt: now})
+		symbols = append(symbols, symbol)
+	}
+	if len(out) == 0 {
+		return out, nil
+	}
+
+	quotes, err := c.Quotes(ctx, symbols)
+	if err != nil {
+		return nil, err
+	}
+	prices := make(map[string]float64, len(quotes))
+	for _, q := range quotes {
+		prices[strings.ToUpper(q.Symbol)] = q.Last
+	}
+	for i := range out {
+		if out[i].Symbol == "USD-USD" {
+			out[i].MarketValue = out[i].Quantity
+			continue
+		}
+		if last, ok := prices[strings.ToUpper(out[i].Symbol)]; ok {
+			out[i].MarketValue = out[i].Quantity * last
+		}
 	}
 	return out, nil
 }

--- a/internal/broker/coinbase/client_test.go
+++ b/internal/broker/coinbase/client_test.go
@@ -51,3 +51,50 @@ func TestQuotesRetryAndCache(t *testing.T) {
 		t.Fatalf("expected spot retries, got %d", spotHits)
 	}
 }
+
+func TestPositionsAndAccountSummaryComputeMarketValue(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/accounts":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"accounts":[{"currency":"BTC","available_balance":"2"},{"currency":"USD","available_balance":"10"}]}`))
+		case "/api/v3/brokerage/products":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"products":[{"product_id":"BTC-USD","base_increment":"0.00000001","quote_increment":"0.01","trading_disabled":false},{"product_id":"USD-USD","base_increment":"0.01","quote_increment":"0.01","trading_disabled":false}]}`))
+		case "/v2/prices/BTC-USD/spot":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"amount":"100"}}`))
+		case "/v2/prices/USD-USD/spot":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"amount":"1"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewReadOnly(ts.Client(), ts.URL)
+	ctx := context.Background()
+
+	positions, err := c.Positions(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(positions) != 2 {
+		t.Fatalf("expected 2 positions, got %d", len(positions))
+	}
+	if positions[0].Symbol != "BTC-USD" || positions[0].MarketValue != 200 {
+		t.Fatalf("unexpected BTC position: %+v", positions[0])
+	}
+	if positions[1].Symbol != "USD-USD" || positions[1].MarketValue != 10 {
+		t.Fatalf("unexpected USD position: %+v", positions[1])
+	}
+
+	summary, err := c.AccountSummary(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.NetLiquidation != 210 || summary.TotalCash != 210 || summary.BuyingPower != 210 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+}


### PR DESCRIPTION
### Motivation
- Coinbase-backed portfolios were reporting zero valuation because `Positions` did not price assets, making `AccountSummary` totals meaningless for crypto holdings.
- The change ensures portfolio totals reflect real USD market values for Coinbase accounts so downstream features (summaries, dashboards, alerts) show accurate numbers.

### Description
- Updated `internal/broker/coinbase/client.go` `Positions` to collect symbols, call `Quotes`, and populate each `Position.MarketValue` by multiplying `Quantity` by the spot `Last` price.
- Special-cased `USD-USD` to treat cash as 1:1 so cash positions use their nominal quantity as market value.
- `AccountSummary` now benefits from the computed `MarketValue` by summing positions for `NetLiquidation`, `TotalCash`, and `BuyingPower` (no API change to summary behavior).
- Added `TestPositionsAndAccountSummaryComputeMarketValue` to `internal/broker/coinbase/client_test.go` to verify positions valuation and summary totals alongside the existing `Quotes` retry/cache test.

### Testing
- Ran `go test ./...` and the test suite completed successfully with the `internal/broker/coinbase` tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab30ed8208329b44b26d559c76e76)