### PR TITLE
coinbase: add canonical/provider symbol normalization and mapping with tests

### DIFF
--- a/.board/milestones/coinbase/cb-05.md
+++ b/.board/milestones/coinbase/cb-05.md
@@ -12,3 +12,8 @@ Implement canonical symbol mapping to provider product IDs.
 - Mapping used by quotes/positions paths.
 - Edge cases documented (BTC-USD/BTCUSD etc.).
 - Tests for mapping consistency.
+
+## Edge case notes
+- `BTC-USD`, `btc/usd`, and `BTCUSD` all normalize to provider product ID `BTC-USD`.
+- Provider symbols are normalized to uppercase with dash separators (e.g., `btc/usd` -> `BTC-USD`).
+- Symbols without an explicit quote currency default to `-USD` (e.g., `AAPL` -> `AAPL-USD`).

--- a/internal/broker/coinbase/client.go
+++ b/internal/broker/coinbase/client.go
@@ -67,7 +67,7 @@ func (c *Client) Positions(ctx context.Context) ([]broker.Position, error) {
 		if q == 0 {
 			continue
 		}
-		symbol := strings.ToUpper(a.Currency) + "-USD"
+		symbol := ProviderToCanonicalSymbol(strings.ToUpper(a.Currency) + "-USD")
 		out = append(out, broker.Position{Symbol: symbol, Quantity: q, Currency: "USD", UpdatedAt: now})
 		symbols = append(symbols, symbol)
 	}
@@ -110,7 +110,7 @@ func (c *Client) AccountSummary(ctx context.Context) (*broker.AccountSummary, er
 func (c *Client) Quotes(ctx context.Context, symbols []string) ([]broker.Quote, error) {
 	quotes := make([]broker.Quote, 0, len(symbols))
 	for _, s := range symbols {
-		productID := normalizeProductID(s)
+		productID := CanonicalToProviderSymbol(s)
 		if err := c.ensureProductCached(ctx, productID); err != nil {
 			return nil, err
 		}
@@ -126,14 +126,6 @@ func (c *Client) Quotes(ctx context.Context, symbols []string) ([]broker.Quote, 
 		quotes = append(quotes, broker.Quote{Symbol: productID, Last: last, Bid: last, Ask: last, UpdatedAt: time.Now().UTC()})
 	}
 	return quotes, nil
-}
-
-func normalizeProductID(symbol string) string {
-	s := strings.ToUpper(strings.TrimSpace(symbol))
-	if strings.Contains(s, "-") {
-		return s
-	}
-	return s + "-USD"
 }
 
 func (c *Client) ensureProductCached(ctx context.Context, productID string) error {

--- a/internal/broker/coinbase/symbols.go
+++ b/internal/broker/coinbase/symbols.go
@@ -1,0 +1,43 @@
+package coinbase
+
+import "strings"
+
+// CanonicalToProviderSymbol maps internal canonical symbols to Coinbase product IDs.
+// Accepted canonical forms include "BTC-USD", "BTC/USD", and "BTCUSD".
+func CanonicalToProviderSymbol(symbol string) string {
+	s := strings.ToUpper(strings.TrimSpace(symbol))
+	if s == "" {
+		return ""
+	}
+	s = strings.ReplaceAll(s, "/", "-")
+	if strings.Contains(s, "-") {
+		parts := strings.Split(s, "-")
+		if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+			return parts[0] + "-" + parts[1]
+		}
+	}
+	if len(s) > 3 {
+		for _, quote := range []string{"USD", "USDC", "EUR", "GBP"} {
+			if strings.HasSuffix(s, quote) && len(s) > len(quote) {
+				base := strings.TrimSuffix(s, quote)
+				if base != "" {
+					return base + "-" + quote
+				}
+			}
+		}
+	}
+	if strings.Contains(s, "-") {
+		return s
+	}
+	return s + "-USD"
+}
+
+// ProviderToCanonicalSymbol maps Coinbase product IDs to canonical symbol format.
+func ProviderToCanonicalSymbol(productID string) string {
+	s := strings.ToUpper(strings.TrimSpace(productID))
+	s = strings.ReplaceAll(s, "/", "-")
+	if strings.Contains(s, "-") {
+		return s
+	}
+	return s + "-USD"
+}

--- a/internal/broker/coinbase/symbols_test.go
+++ b/internal/broker/coinbase/symbols_test.go
@@ -1,0 +1,42 @@
+package coinbase
+
+import "testing"
+
+func TestCanonicalToProviderSymbol(t *testing.T) {
+	tests := map[string]string{
+		"BTC-USD": "BTC-USD",
+		"btc-usd": "BTC-USD",
+		"BTC/USD": "BTC-USD",
+		"BTCUSD":  "BTC-USD",
+		"ethusdc": "ETH-USDC",
+		"AAPL":    "AAPL-USD",
+	}
+	for in, want := range tests {
+		if got := CanonicalToProviderSymbol(in); got != want {
+			t.Fatalf("CanonicalToProviderSymbol(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestProviderToCanonicalSymbol(t *testing.T) {
+	tests := map[string]string{
+		"BTC-USD": "BTC-USD",
+		"btc/usd": "BTC-USD",
+	}
+	for in, want := range tests {
+		if got := ProviderToCanonicalSymbol(in); got != want {
+			t.Fatalf("ProviderToCanonicalSymbol(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSymbolRoundTripConsistency(t *testing.T) {
+	inputs := []string{"BTC-USD", "BTC/USD", "btcusd", "ETHUSDC", "SOL-USD"}
+	for _, in := range inputs {
+		provider := CanonicalToProviderSymbol(in)
+		canon := ProviderToCanonicalSymbol(provider)
+		if canon != provider {
+			t.Fatalf("round-trip mismatch for %q: provider=%q canon=%q", in, provider, canon)
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a consistent canonical↔provider symbol mapping for Coinbase to handle mixed symbol formats such as `BTC-USD`, `btc/usd`, and `BTCUSD`.
- Ensure quotes and positions use the canonical/provider mappings so prices and market values remain consistent across codepaths.
- Document common edge cases for normalization so behavior is explicit for symbols without explicit quote currencies and different separators.

### Description
- Added `internal/broker/coinbase/symbols.go` with `CanonicalToProviderSymbol` and `ProviderToCanonicalSymbol` to perform normalization and mapping.
- Updated `internal/broker/coinbase/client.go` to use `ProviderToCanonicalSymbol` when building positions and `CanonicalToProviderSymbol` when looking up quotes, and removed the old `normalizeProductID` logic.
- Added unit tests in `internal/broker/coinbase/symbols_test.go` that validate common formats and round-trip consistency between canonical and provider forms.
- Updated milestone notes at `.board/milestones/coinbase/cb-05.md` to document edge-case normalization behavior.

### Testing
- Ran `go test ./internal/broker/coinbase` and the new symbol tests passed.
- Package tests were run as part of the change and reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69facac4901083298bf94be900b44979)