### PR TITLE
SCH-17: align frontend react-dom/@types to v18 and relax Docker install peer resolution

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm ci
+RUN npm install --legacy-peer-deps
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,14 +18,14 @@
     "next": "14.2.18",
     "next-themes": "^0.4.6",
     "react": "^18",
-    "react-dom": "^19",
+    "react-dom": "^18",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@types/node": "^25",
     "@types/react": "^18",
-    "@types/react-dom": "^19",
+    "@types/react-dom": "^18",
     "eslint": "^10",
     "eslint-config-next": "16.2.6",
     "postcss": "^8",


### PR DESCRIPTION
### Motivation
- Fix the Docker image build failure where the frontend `npm ci` step failed due to a peer dependency mismatch between `@types/react-dom@19.x` and the project `@types/react@^18`.

### Description
- Updated `frontend/package.json` to change `react-dom` from `^19` to `^18` to match the project React version.
- Updated `frontend/package.json` to change `@types/react-dom` from `^19` to `^18` to align TypeScript typings with `@types/react@^18`.
- Updated `frontend/Dockerfile` to replace `RUN npm ci` with `RUN npm install --legacy-peer-deps` to avoid strict peer-resolution failures during container image builds with the current lockfile.

### Testing
- Ran `cd frontend && npm install` to validate dependency resolution, which failed with a `403 Forbidden` from the npm registry so lockfile regeneration could not be completed in this environment.
- The original `docker compose -f docker-compose.yml -f docker-compose.coinbase.yml up -d --build` failure was reproduced and traced to the `npm ci` peer-resolution error, and the change to `npm install --legacy-peer-deps` is expected to prevent that failure (full image build validation was not possible due to the registry access error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0399edf9f083298f0e056b4b811923)