### PR TITLE
frontend: use legacy-peer-deps install, align react-dom to v18, and update PostCSS plugin

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm ci
+RUN npm install --legacy-peer-deps
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,14 +18,15 @@
     "next": "14.2.18",
     "next-themes": "^0.4.6",
     "react": "^18",
-    "react-dom": "^19",
+    "react-dom": "^18",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.11",
     "@types/node": "^25",
     "@types/react": "^18",
-    "@types/react-dom": "^19",
+    "@types/react-dom": "^18",
     "eslint": "^10",
     "eslint-config-next": "16.2.6",
     "postcss": "^8",

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('postcss-load-config').Config} */
 const config = {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
   },
 };
 


### PR DESCRIPTION
### Motivation
- Fix frontend install/build issues caused by peer dependency conflicts during Docker image builds. 
- Align `react-dom` and `@types/react-dom` with the installed `react` v18 to remove type/runtime mismatches. 
- Update PostCSS plugin configuration to match the Tailwind/PostCSS integration expected by the project.

### Description
- Replace `npm ci` with `npm install --legacy-peer-deps` in `frontend/Dockerfile` to avoid peer-dependency installation failures. 
- Change `react-dom` and `@types/react-dom` from `^19` to `^18` in `frontend/package.json` to match `react` `^18`. 
- Add `@tailwindcss/postcss` as a devDependency in `frontend/package.json` and update `frontend/postcss.config.mjs` to use the `"@tailwindcss/postcss"` plugin. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0399edf9f083298f0e056b4b811923)