### PR TITLE
add the lab dashboard

### DIFF
--- a/backend/cmd/portfolio-api/followed_handlers.go
+++ b/backend/cmd/portfolio-api/followed_handlers.go
@@ -80,6 +80,10 @@ func (a *app) handleAlertSettingsUpdate(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if _, err := a.repo.InsertSignalSettingsVersion(r.Context(), req, "save"); err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
 	if err := a.repo.UpdateSignalSettings(r.Context(), req); err != nil {
 		http.Error(w, "server error", http.StatusInternalServerError)
 		return

--- a/backend/cmd/portfolio-api/followed_handlers_test.go
+++ b/backend/cmd/portfolio-api/followed_handlers_test.go
@@ -17,16 +17,23 @@ import (
 )
 
 type fakePortfolioRepo struct {
-	followed      map[string]portfolio.FollowedSymbol
-	seeded        bool
-	snapshot      []byte
-	signalSetting *portfolio.SignalSettings
-	recentAlerts  []portfolio.RecentAlert
+	followed         map[string]portfolio.FollowedSymbol
+	seeded           bool
+	snapshot         []byte
+	signalSetting    *portfolio.SignalSettings
+	recentAlerts     []portfolio.RecentAlert
+	labSignals       []portfolio.LabSignalEvent
+	labRuns          map[string]portfolio.LabOpenClawRun
+	labNotes         []portfolio.LabNote
+	control          portfolio.LabControlState
+	settingsVersions []portfolio.SignalSettingsVersion
 }
 
 func newFakePortfolioRepo() *fakePortfolioRepo {
 	return &fakePortfolioRepo{
 		followed: map[string]portfolio.FollowedSymbol{},
+		labRuns:  map[string]portfolio.LabOpenClawRun{},
+		control:  portfolio.LabControlState{UpdatedAt: time.Unix(0, 0).UTC()},
 		signalSetting: &portfolio.SignalSettings{
 			MoveThresholdPct: 1.0,
 			Cooldown:         "15m",
@@ -85,6 +92,99 @@ func (f *fakePortfolioRepo) InsertRecentAlert(_ context.Context, alert portfolio
 	alert.ID = int64(len(f.recentAlerts) + 1)
 	alert.CreatedAt = time.Now().UTC()
 	f.recentAlerts = append(f.recentAlerts, alert)
+	return nil
+}
+func (f *fakePortfolioRepo) InsertLabSignalEvent(_ context.Context, alert portfolio.RecentAlert) (*portfolio.LabSignalEvent, error) {
+	item := portfolio.LabSignalEvent{
+		ID:            int64(len(f.labSignals) + 1),
+		Type:          alert.Type,
+		Symbol:        alert.Symbol,
+		ProductID:     alert.ProductID,
+		Source:        alert.Source,
+		CurrentPrice:  alert.CurrentPrice,
+		PreviousPrice: alert.PreviousPrice,
+		DeltaAmount:   alert.DeltaAmount,
+		DeltaPct:      alert.DeltaPct,
+		ThresholdPct:  alert.ThresholdPct,
+		FiredAt:       alert.FiredAt,
+		PayloadJSON:   alert.PayloadJSON,
+		DiscordStatus: "signal_only",
+		CreatedAt:     time.Now().UTC(),
+	}
+	f.labSignals = append(f.labSignals, item)
+	return &item, nil
+}
+func (f *fakePortfolioRepo) ListLabSignalEvents(_ context.Context, filter portfolio.LabSignalFilter) ([]portfolio.LabSignalEvent, error) {
+	out := make([]portfolio.LabSignalEvent, len(f.labSignals))
+	copy(out, f.labSignals)
+	return out, nil
+}
+func (f *fakePortfolioRepo) GetLabSignalEvent(_ context.Context, id int64) (*portfolio.LabSignalEvent, error) {
+	for _, item := range f.labSignals {
+		if item.ID == id {
+			return &item, nil
+		}
+	}
+	return nil, pgx.ErrNoRows
+}
+func (f *fakePortfolioRepo) UpsertLabOpenClawRun(_ context.Context, run portfolio.LabOpenClawRun) error {
+	if run.Attempts == 0 {
+		run.Attempts = 1
+	}
+	run.UpdatedAt = time.Now().UTC()
+	f.labRuns[run.RequestID] = run
+	return nil
+}
+func (f *fakePortfolioRepo) ListLabOpenClawRuns(_ context.Context, filter portfolio.LabRunFilter) ([]portfolio.LabOpenClawRun, error) {
+	out := make([]portfolio.LabOpenClawRun, 0, len(f.labRuns))
+	for _, run := range f.labRuns {
+		out = append(out, run)
+	}
+	return out, nil
+}
+func (f *fakePortfolioRepo) GetLabOpenClawRun(_ context.Context, requestID string) (*portfolio.LabOpenClawRun, error) {
+	run, ok := f.labRuns[requestID]
+	if !ok {
+		return nil, pgx.ErrNoRows
+	}
+	return &run, nil
+}
+func (f *fakePortfolioRepo) InsertLabNote(_ context.Context, req portfolio.LabNoteRequest) (*portfolio.LabNote, error) {
+	note := portfolio.LabNote{ID: int64(len(f.labNotes) + 1), SignalID: req.SignalID, RequestID: req.RequestID, Body: req.Body, CreatedAt: time.Now().UTC()}
+	f.labNotes = append(f.labNotes, note)
+	return &note, nil
+}
+func (f *fakePortfolioRepo) ListLabTelemetry(context.Context, string, string) ([]portfolio.LabTelemetryPoint, error) {
+	return nil, nil
+}
+func (f *fakePortfolioRepo) GetLabControlState(context.Context) (*portfolio.LabControlState, error) {
+	return &f.control, nil
+}
+func (f *fakePortfolioRepo) UpdateLabControlState(_ context.Context, control portfolio.LabControlState) (*portfolio.LabControlState, error) {
+	control.UpdatedAt = time.Now().UTC()
+	f.control = control
+	return &f.control, nil
+}
+func (f *fakePortfolioRepo) InsertSignalSettingsVersion(_ context.Context, req portfolio.SignalSettingsRequest, reason string) (*portfolio.SignalSettingsVersion, error) {
+	version := portfolio.SignalSettingsVersion{ID: int64(len(f.settingsVersions) + 1), MoveThresholdPct: req.MoveThresholdPct, Cooldown: req.Cooldown, Reason: reason, CreatedAt: time.Now().UTC()}
+	f.settingsVersions = append(f.settingsVersions, version)
+	return &version, nil
+}
+func (f *fakePortfolioRepo) ListSignalSettingsVersions(context.Context, int) ([]portfolio.SignalSettingsVersion, error) {
+	out := make([]portfolio.SignalSettingsVersion, len(f.settingsVersions))
+	copy(out, f.settingsVersions)
+	return out, nil
+}
+func (f *fakePortfolioRepo) RevertSignalSettings(_ context.Context, versionID int64) (*portfolio.SignalSettings, error) {
+	for _, version := range f.settingsVersions {
+		if version.ID == versionID {
+			f.signalSetting = &portfolio.SignalSettings{MoveThresholdPct: version.MoveThresholdPct, Cooldown: version.Cooldown, UpdatedAt: time.Now().UTC()}
+			return f.signalSetting, nil
+		}
+	}
+	return nil, pgx.ErrNoRows
+}
+func (f *fakePortfolioRepo) CompactLabOpenClawPayloads(context.Context, time.Time) error {
 	return nil
 }
 func (f *fakePortfolioRepo) CreateSession(context.Context, string, string, time.Time) error {
@@ -205,6 +305,12 @@ func TestRecentAlertsHandlers(t *testing.T) {
 	if len(repo.recentAlerts) != 1 || repo.recentAlerts[0].Symbol != "BTC-USD" {
 		t.Fatalf("unexpected insert: %+v", repo.recentAlerts)
 	}
+	if len(repo.labSignals) != 1 || repo.labSignals[0].Symbol != "BTC-USD" {
+		t.Fatalf("expected lab signal insert: %+v", repo.labSignals)
+	}
+	if _, ok := repo.labRuns["lab-signal-1-attempt-1"]; !ok {
+		t.Fatalf("expected queued lab run: %+v", repo.labRuns)
+	}
 	if len(repo.recentAlerts[0].PayloadJSON) == 0 || !bytes.Contains(repo.recentAlerts[0].PayloadJSON, []byte(`"schemaVersion":"crypto_signal_v1"`)) {
 		t.Fatalf("expected payload_json: %s", repo.recentAlerts[0].PayloadJSON)
 	}
@@ -221,5 +327,30 @@ func TestRecentAlertsHandlers(t *testing.T) {
 	}
 	if len(resp.Alerts) != 1 || resp.Alerts[0].Symbol != "BTC-USD" {
 		t.Fatalf("unexpected alerts: %+v", resp.Alerts)
+	}
+}
+
+func TestLabOperationHandlers(t *testing.T) {
+	repo := newFakePortfolioRepo()
+	app := &app{repo: repo}
+
+	pauseReq := httptest.NewRequest(http.MethodPost, "/api/lab/openclaw/pause", nil)
+	pauseRec := httptest.NewRecorder()
+	app.handleLabOpenClawPause(pauseRec, pauseReq)
+	if pauseRec.Code != http.StatusOK {
+		t.Fatalf("pause status: %d", pauseRec.Code)
+	}
+	if !repo.control.OpenClawPaused {
+		t.Fatal("expected OpenClaw paused")
+	}
+
+	resumeReq := httptest.NewRequest(http.MethodPost, "/api/lab/openclaw/resume", nil)
+	resumeRec := httptest.NewRecorder()
+	app.handleLabOpenClawResume(resumeRec, resumeReq)
+	if resumeRec.Code != http.StatusOK {
+		t.Fatalf("resume status: %d", resumeRec.Code)
+	}
+	if repo.control.OpenClawPaused {
+		t.Fatal("expected OpenClaw resumed")
 	}
 }

--- a/backend/cmd/portfolio-api/internal_handler.go
+++ b/backend/cmd/portfolio-api/internal_handler.go
@@ -86,6 +86,7 @@ func (a *app) handleInternalRecentAlertCreate(w http.ResponseWriter, r *http.Req
 		http.Error(w, "server error", http.StatusInternalServerError)
 		return
 	}
+	a.recordLabSignal(r, alert)
 	if a.log != nil {
 		a.log.Info("recent_alert_insert", "symbol", alert.Symbol, "delta_pct", alert.DeltaPct, "threshold_pct", alert.ThresholdPct)
 	}

--- a/backend/cmd/portfolio-api/lab_handlers.go
+++ b/backend/cmd/portfolio-api/lab_handlers.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/schtvr/morgans-d-stonks/internal/openclaw"
+	"github.com/schtvr/morgans-d-stonks/internal/portfolio"
+)
+
+const labPayloadRetention = 60 * 24 * time.Hour
+
+func (a *app) handleLabOverview(w http.ResponseWriter, r *http.Request) {
+	control, err := a.repo.GetLabControlState(r.Context())
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	signals, err := a.repo.ListLabSignalEvents(r.Context(), portfolio.LabSignalFilter{Limit: 8})
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	runs, err := a.repo.ListLabOpenClawRuns(r.Context(), portfolio.LabRunFilter{Limit: 8})
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, portfolio.LabOverviewResponse{
+		Control:       *control,
+		RecentSignals: signals,
+		RecentRuns:    runs,
+	})
+}
+
+func (a *app) handleLabSignalsList(w http.ResponseWriter, r *http.Request) {
+	filter, err := parseLabSignalFilter(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	items, err := a.repo.ListLabSignalEvents(r.Context(), filter)
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, portfolio.LabSignalsResponse{Signals: items})
+}
+
+func (a *app) handleLabSignalGet(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		http.Error(w, "invalid signal id", http.StatusBadRequest)
+		return
+	}
+	item, err := a.repo.GetLabSignalEvent(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, item)
+}
+
+func (a *app) handleLabRunsList(w http.ResponseWriter, r *http.Request) {
+	signalID, _ := strconv.ParseInt(strings.TrimSpace(r.URL.Query().Get("signalId")), 10, 64)
+	runs, err := a.repo.ListLabOpenClawRuns(r.Context(), portfolio.LabRunFilter{
+		Limit:    parsePositiveInt(r.URL.Query().Get("limit"), 50),
+		Status:   strings.TrimSpace(r.URL.Query().Get("status")),
+		SignalID: signalID,
+	})
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, portfolio.LabRunsResponse{Runs: runs})
+}
+
+func (a *app) handleLabRunGet(w http.ResponseWriter, r *http.Request) {
+	run, err := a.repo.GetLabOpenClawRun(r.Context(), chi.URLParam(r, "requestId"))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, run)
+}
+
+func (a *app) handleLabRunRetry(w http.ResponseWriter, r *http.Request) {
+	requestID := chi.URLParam(r, "requestId")
+	run, err := a.repo.GetLabOpenClawRun(r.Context(), requestID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	run.Status = openclaw.StatusRetrying
+	run.Attempts++
+	run.ErrorText = ""
+	run.CompletedAt = nil
+	if err := a.repo.UpsertLabOpenClawRun(r.Context(), *run); err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	if a.log != nil {
+		a.log.Info("lab_openclaw_retry", "request_id", requestID, "attempts", run.Attempts)
+	}
+	writeJSON(w, http.StatusAccepted, run)
+}
+
+func (a *app) handleLabOpenClawPause(w http.ResponseWriter, r *http.Request) {
+	a.updateLabControl(w, r, func(c portfolio.LabControlState) portfolio.LabControlState {
+		c.OpenClawPaused = true
+		return c
+	}, "OpenClaw forwarding paused")
+}
+
+func (a *app) handleLabOpenClawResume(w http.ResponseWriter, r *http.Request) {
+	a.updateLabControl(w, r, func(c portfolio.LabControlState) portfolio.LabControlState {
+		c.OpenClawPaused = false
+		return c
+	}, "OpenClaw forwarding resumed")
+}
+
+func (a *app) handleLabOpenClawCircuitReset(w http.ResponseWriter, r *http.Request) {
+	a.updateLabControl(w, r, func(c portfolio.LabControlState) portfolio.LabControlState {
+		c.CircuitOpen = false
+		c.CircuitReason = ""
+		return c
+	}, "OpenClaw circuit reset")
+}
+
+func (a *app) updateLabControl(w http.ResponseWriter, r *http.Request, mutate func(portfolio.LabControlState) portfolio.LabControlState, msg string) {
+	control, err := a.repo.GetLabControlState(r.Context())
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	next, err := a.repo.UpdateLabControlState(r.Context(), mutate(*control))
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	if a.log != nil {
+		a.log.Info("lab_control_update", "message", msg, "paused", next.OpenClawPaused, "circuit_open", next.CircuitOpen)
+	}
+	writeJSON(w, http.StatusOK, portfolio.LabOperationResponse{Control: *next, Message: msg})
+}
+
+func (a *app) handleLabNoteCreate(w http.ResponseWriter, r *http.Request) {
+	var req portfolio.LabNoteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	req.Body = strings.TrimSpace(req.Body)
+	req.RequestID = strings.TrimSpace(req.RequestID)
+	if req.Body == "" {
+		http.Error(w, "body is required", http.StatusBadRequest)
+		return
+	}
+	if req.SignalID == nil && req.RequestID == "" {
+		http.Error(w, "signalId or requestId is required", http.StatusBadRequest)
+		return
+	}
+	note, err := a.repo.InsertLabNote(r.Context(), req)
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusCreated, note)
+}
+
+func (a *app) handleLabTelemetry(w http.ResponseWriter, r *http.Request) {
+	window := strings.TrimSpace(r.URL.Query().Get("window"))
+	if window == "" {
+		window = "24h"
+	}
+	if _, err := time.ParseDuration(window); err != nil {
+		http.Error(w, "window must be a valid duration", http.StatusBadRequest)
+		return
+	}
+	points, err := a.repo.ListLabTelemetry(r.Context(), strings.TrimSpace(r.URL.Query().Get("symbol")), window)
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, portfolio.LabTelemetryResponse{Points: points})
+}
+
+func (a *app) handleSignalSettingsHistory(w http.ResponseWriter, r *http.Request) {
+	items, err := a.repo.ListSignalSettingsVersions(r.Context(), parsePositiveInt(r.URL.Query().Get("limit"), 10))
+	if err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, portfolio.SignalSettingsHistoryResponse{Versions: items})
+}
+
+func (a *app) handleSignalSettingsRevert(w http.ResponseWriter, r *http.Request) {
+	var req portfolio.SignalSettingsRevertRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if req.VersionID <= 0 {
+		http.Error(w, "versionId is required", http.StatusBadRequest)
+		return
+	}
+	settings, err := a.repo.RevertSignalSettings(r.Context(), req.VersionID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, settings)
+}
+
+func (a *app) recordLabSignal(ctxReq *http.Request, alert portfolio.RecentAlert) {
+	event, err := a.repo.InsertLabSignalEvent(ctxReq.Context(), alert)
+	if err != nil {
+		if a.log != nil {
+			a.log.Warn("lab_signal_insert", "err", err, "symbol", alert.Symbol)
+		}
+		return
+	}
+	control, err := a.repo.GetLabControlState(ctxReq.Context())
+	if err != nil {
+		if a.log != nil {
+			a.log.Warn("lab_control_get", "err", err)
+		}
+		return
+	}
+	if control.OpenClawPaused || control.CircuitOpen {
+		status := openclaw.StatusSkipped
+		reason := "paused"
+		if control.CircuitOpen {
+			reason = "circuit_open"
+		}
+		_ = a.repo.UpsertLabOpenClawRun(ctxReq.Context(), portfolio.LabOpenClawRun{
+			RequestID:   labRequestID(event.ID, 1),
+			SignalID:    event.ID,
+			Status:      status,
+			Attempts:    1,
+			ErrorText:   reason,
+			RequestHash: hashRaw(event.PayloadJSON),
+			RequestJSON: event.PayloadJSON,
+		})
+		return
+	}
+	if err := a.repo.UpsertLabOpenClawRun(ctxReq.Context(), portfolio.LabOpenClawRun{
+		RequestID:   labRequestID(event.ID, 1),
+		SignalID:    event.ID,
+		Status:      openclaw.StatusQueued,
+		Attempts:    1,
+		RequestHash: hashRaw(event.PayloadJSON),
+		RequestJSON: event.PayloadJSON,
+		StartedAt:   timePtr(time.Now().UTC()),
+	}); err != nil && a.log != nil {
+		a.log.Warn("lab_openclaw_enqueue", "err", err, "signal_id", event.ID)
+	}
+}
+
+func parseLabSignalFilter(r *http.Request) (portfolio.LabSignalFilter, error) {
+	filter := portfolio.LabSignalFilter{
+		Limit:  parsePositiveInt(r.URL.Query().Get("limit"), 50),
+		Symbol: strings.TrimSpace(r.URL.Query().Get("symbol")),
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("from")); raw != "" {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return filter, fmt.Errorf("from must be RFC3339: %w", err)
+		}
+		filter.From = &t
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("to")); raw != "" {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return filter, fmt.Errorf("to must be RFC3339: %w", err)
+		}
+		filter.To = &t
+	}
+	return filter, nil
+}
+
+func labRequestID(signalID int64, attempt int) string {
+	return fmt.Sprintf("lab-signal-%d-attempt-%d", signalID, attempt)
+}
+
+func hashRaw(raw json.RawMessage) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/backend/cmd/portfolio-api/main.go
+++ b/backend/cmd/portfolio-api/main.go
@@ -70,6 +70,9 @@ func main() {
 	if err := seedFollowedSymbolsFromLatestSnapshot(ctx, repo); err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		log.Warn("seed followed symbols", "err", err)
 	}
+	if err := repo.CompactLabOpenClawPayloads(ctx, time.Now().UTC().Add(-labPayloadRetention)); err != nil {
+		log.Warn("compact lab payloads", "err", err)
+	}
 
 	app := &app{
 		cfg:        cfg,
@@ -119,6 +122,21 @@ func main() {
 		r.Get("/api/trading/alert-settings", app.handleAlertSettingsGet)
 		r.Put("/api/trading/alert-settings", app.handleAlertSettingsUpdate)
 		r.Get("/api/trading/recent-alerts", app.handleRecentAlertsList)
+		r.Route("/api/lab", func(r chi.Router) {
+			r.Get("/overview", app.handleLabOverview)
+			r.Get("/signals", app.handleLabSignalsList)
+			r.Get("/signals/{id}", app.handleLabSignalGet)
+			r.Get("/runs", app.handleLabRunsList)
+			r.Get("/runs/{requestId}", app.handleLabRunGet)
+			r.Post("/runs/{requestId}/retry", app.handleLabRunRetry)
+			r.Post("/openclaw/pause", app.handleLabOpenClawPause)
+			r.Post("/openclaw/resume", app.handleLabOpenClawResume)
+			r.Post("/openclaw/circuit/reset", app.handleLabOpenClawCircuitReset)
+			r.Post("/notes", app.handleLabNoteCreate)
+			r.Get("/telemetry", app.handleLabTelemetry)
+			r.Get("/signal-settings/history", app.handleSignalSettingsHistory)
+			r.Post("/signal-settings/revert", app.handleSignalSettingsRevert)
+		})
 		if app.tradingCfg.Enabled {
 			r.Get("/api/trading/orders/open", app.handleOpenOrdersList)
 		}

--- a/backend/internal/openclaw/types.go
+++ b/backend/internal/openclaw/types.go
@@ -1,0 +1,9 @@
+package openclaw
+
+const (
+	StatusQueued    = "queued"
+	StatusRetrying  = "retrying"
+	StatusSkipped   = "skipped"
+	StatusCompleted = "completed"
+	StatusFailed    = "failed"
+)

--- a/backend/internal/openclaw/types_test.go
+++ b/backend/internal/openclaw/types_test.go
@@ -1,0 +1,9 @@
+package openclaw
+
+import "testing"
+
+func TestStatusesAreStableForLabAPI(t *testing.T) {
+	if StatusQueued != "queued" || StatusRetrying != "retrying" || StatusSkipped != "skipped" {
+		t.Fatalf("unexpected status constants")
+	}
+}

--- a/backend/internal/portfolio/postgres/migrations/006_lab.sql
+++ b/backend/internal/portfolio/postgres/migrations/006_lab.sql
@@ -1,0 +1,88 @@
+CREATE TABLE IF NOT EXISTS lab_signal_events (
+    id BIGSERIAL PRIMARY KEY,
+    source_alert_id BIGINT,
+    type TEXT NOT NULL DEFAULT 'crypto_price_move',
+    symbol TEXT NOT NULL,
+    product_id TEXT NOT NULL DEFAULT '',
+    source TEXT NOT NULL DEFAULT '',
+    current_price DOUBLE PRECISION NOT NULL,
+    previous_price DOUBLE PRECISION,
+    delta_amount DOUBLE PRECISION,
+    delta_pct DOUBLE PRECISION NOT NULL,
+    threshold_pct DOUBLE PRECISION NOT NULL,
+    fired_at TIMESTAMPTZ NOT NULL,
+    payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    discord_status TEXT NOT NULL DEFAULT 'signal_only',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lab_signal_events_fired_at
+    ON lab_signal_events (fired_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_lab_signal_events_symbol_fired_at
+    ON lab_signal_events (symbol, fired_at DESC);
+
+CREATE TABLE IF NOT EXISTS lab_openclaw_runs (
+    request_id TEXT PRIMARY KEY,
+    signal_event_id BIGINT NOT NULL REFERENCES lab_signal_events(id) ON DELETE CASCADE,
+    status TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 1,
+    analysis TEXT NOT NULL DEFAULT '',
+    recommendation TEXT NOT NULL DEFAULT '',
+    confidence DOUBLE PRECISION,
+    tool_names TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    error_text TEXT NOT NULL DEFAULT '',
+    request_hash TEXT NOT NULL DEFAULT '',
+    response_hash TEXT NOT NULL DEFAULT '',
+    full_request_json JSONB,
+    full_response_json JSONB,
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lab_openclaw_runs_signal_event_id
+    ON lab_openclaw_runs (signal_event_id);
+
+CREATE INDEX IF NOT EXISTS idx_lab_openclaw_runs_status_updated_at
+    ON lab_openclaw_runs (status, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS lab_notes (
+    id BIGSERIAL PRIMARY KEY,
+    signal_event_id BIGINT REFERENCES lab_signal_events(id) ON DELETE CASCADE,
+    request_id TEXT REFERENCES lab_openclaw_runs(request_id) ON DELETE CASCADE,
+    body TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (signal_event_id IS NOT NULL OR request_id IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lab_notes_signal_event_id
+    ON lab_notes (signal_event_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_lab_notes_request_id
+    ON lab_notes (request_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS signal_settings_versions (
+    id BIGSERIAL PRIMARY KEY,
+    move_threshold_pct DOUBLE PRECISION NOT NULL,
+    cooldown TEXT NOT NULL,
+    reason TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_signal_settings_versions_created_at
+    ON signal_settings_versions (created_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS lab_control_state (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE,
+    openclaw_paused BOOLEAN NOT NULL DEFAULT FALSE,
+    circuit_open BOOLEAN NOT NULL DEFAULT FALSE,
+    circuit_reason TEXT NOT NULL DEFAULT '',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (singleton = TRUE)
+);
+
+INSERT INTO lab_control_state (singleton)
+VALUES (TRUE)
+ON CONFLICT (singleton) DO NOTHING;

--- a/backend/internal/portfolio/postgres/migrations_test.go
+++ b/backend/internal/portfolio/postgres/migrations_test.go
@@ -54,3 +54,21 @@ func TestMigrationContainsRecentAlertPayloadJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestMigrationContainsLabTables(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("migrations", "006_lab.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"CREATE TABLE IF NOT EXISTS lab_signal_events",
+		"CREATE TABLE IF NOT EXISTS lab_openclaw_runs",
+		"CREATE TABLE IF NOT EXISTS lab_notes",
+		"CREATE TABLE IF NOT EXISTS signal_settings_versions",
+		"CREATE TABLE IF NOT EXISTS lab_control_state",
+	} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("missing %q in migration", want)
+		}
+	}
+}

--- a/backend/internal/portfolio/postgres/repository.go
+++ b/backend/internal/portfolio/postgres/repository.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -244,11 +245,426 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, now(),
 	return err
 }
 
+// InsertLabSignalEvent records a qualifying crypto signal for The Lab.
+func (r *Repository) InsertLabSignalEvent(ctx context.Context, alert portfolio.RecentAlert) (*portfolio.LabSignalEvent, error) {
+	const q = `
+INSERT INTO lab_signal_events (
+    type, symbol, product_id, source, current_price, previous_price, delta_amount, delta_pct, threshold_pct,
+    fired_at, payload_json, discord_status
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, 'signal_only')
+RETURNING id, type, symbol, product_id, source, current_price, previous_price, delta_amount, delta_pct,
+          threshold_pct, fired_at, payload_json, discord_status, created_at`
+	var item portfolio.LabSignalEvent
+	err := r.pool.QueryRow(
+		ctx,
+		q,
+		alert.Type,
+		alert.Symbol,
+		alert.ProductID,
+		alert.Source,
+		alert.CurrentPrice,
+		alert.PreviousPrice,
+		alert.DeltaAmount,
+		alert.DeltaPct,
+		alert.ThresholdPct,
+		alert.FiredAt,
+		payloadJSONBytes(alert.PayloadJSON),
+	).Scan(
+		&item.ID,
+		&item.Type,
+		&item.Symbol,
+		&item.ProductID,
+		&item.Source,
+		&item.CurrentPrice,
+		&item.PreviousPrice,
+		&item.DeltaAmount,
+		&item.DeltaPct,
+		&item.ThresholdPct,
+		&item.FiredAt,
+		&item.PayloadJSON,
+		&item.DiscordStatus,
+		&item.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+// ListLabSignalEvents returns newest Lab signals with simple filters.
+func (r *Repository) ListLabSignalEvents(ctx context.Context, filter portfolio.LabSignalFilter) ([]portfolio.LabSignalEvent, error) {
+	limit := clampLimit(filter.Limit, 50, 200)
+	const q = `
+SELECT id, type, symbol, product_id, source, current_price, previous_price, delta_amount, delta_pct,
+       threshold_pct, fired_at, payload_json, discord_status, created_at
+FROM lab_signal_events
+WHERE ($2 = '' OR symbol = $2)
+  AND ($3::timestamptz IS NULL OR fired_at >= $3)
+  AND ($4::timestamptz IS NULL OR fired_at <= $4)
+ORDER BY fired_at DESC, id DESC
+LIMIT $1`
+	rows, err := r.pool.Query(ctx, q, limit, strings.TrimSpace(filter.Symbol), filter.From, filter.To)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]portfolio.LabSignalEvent, 0, limit)
+	for rows.Next() {
+		item, err := scanLabSignalEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+// GetLabSignalEvent returns one durable Lab signal.
+func (r *Repository) GetLabSignalEvent(ctx context.Context, id int64) (*portfolio.LabSignalEvent, error) {
+	const q = `
+SELECT id, type, symbol, product_id, source, current_price, previous_price, delta_amount, delta_pct,
+       threshold_pct, fired_at, payload_json, discord_status, created_at
+FROM lab_signal_events
+WHERE id = $1`
+	rows, err := r.pool.Query(ctx, q, id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return nil, pgx.ErrNoRows
+	}
+	item, err := scanLabSignalEvent(rows)
+	if err != nil {
+		return nil, err
+	}
+	return &item, rows.Err()
+}
+
+// UpsertLabOpenClawRun stores a Lab-visible OpenClaw attempt.
+func (r *Repository) UpsertLabOpenClawRun(ctx context.Context, run portfolio.LabOpenClawRun) error {
+	const q = `
+INSERT INTO lab_openclaw_runs (
+    request_id, signal_event_id, status, attempts, analysis, recommendation, confidence, tool_names,
+    error_text, request_hash, response_hash, full_request_json, full_response_json, started_at, completed_at, updated_at
+)
+VALUES ($1, $2, $3, GREATEST($4, 1), $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb, $14, $15, now())
+ON CONFLICT (request_id) DO UPDATE SET
+    status = EXCLUDED.status,
+    attempts = GREATEST(lab_openclaw_runs.attempts, EXCLUDED.attempts),
+    analysis = EXCLUDED.analysis,
+    recommendation = EXCLUDED.recommendation,
+    confidence = EXCLUDED.confidence,
+    tool_names = EXCLUDED.tool_names,
+    error_text = EXCLUDED.error_text,
+    request_hash = EXCLUDED.request_hash,
+    response_hash = EXCLUDED.response_hash,
+    full_request_json = COALESCE(EXCLUDED.full_request_json, lab_openclaw_runs.full_request_json),
+    full_response_json = COALESCE(EXCLUDED.full_response_json, lab_openclaw_runs.full_response_json),
+    started_at = COALESCE(EXCLUDED.started_at, lab_openclaw_runs.started_at),
+    completed_at = EXCLUDED.completed_at,
+    updated_at = now()`
+	_, err := r.pool.Exec(
+		ctx,
+		q,
+		run.RequestID,
+		run.SignalID,
+		run.Status,
+		run.Attempts,
+		run.Analysis,
+		run.Recommendation,
+		run.Confidence,
+		run.ToolNames,
+		run.ErrorText,
+		run.RequestHash,
+		run.ResponseHash,
+		nullableJSONBytes(run.RequestJSON),
+		nullableJSONBytes(run.ResponseJSON),
+		run.StartedAt,
+		run.CompletedAt,
+	)
+	return err
+}
+
+func (r *Repository) ListLabOpenClawRuns(ctx context.Context, filter portfolio.LabRunFilter) ([]portfolio.LabOpenClawRun, error) {
+	limit := clampLimit(filter.Limit, 50, 200)
+	const q = `
+SELECT request_id, signal_event_id, status, attempts, analysis, recommendation, confidence, tool_names, error_text,
+       request_hash, response_hash, full_request_json, full_response_json, started_at, completed_at, created_at, updated_at
+FROM lab_openclaw_runs
+WHERE ($2 = '' OR status = $2)
+  AND ($3 = 0 OR signal_event_id = $3)
+ORDER BY updated_at DESC, created_at DESC
+LIMIT $1`
+	rows, err := r.pool.Query(ctx, q, limit, strings.TrimSpace(filter.Status), filter.SignalID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]portfolio.LabOpenClawRun, 0, limit)
+	for rows.Next() {
+		item, err := scanLabOpenClawRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) GetLabOpenClawRun(ctx context.Context, requestID string) (*portfolio.LabOpenClawRun, error) {
+	const q = `
+SELECT request_id, signal_event_id, status, attempts, analysis, recommendation, confidence, tool_names, error_text,
+       request_hash, response_hash, full_request_json, full_response_json, started_at, completed_at, created_at, updated_at
+FROM lab_openclaw_runs
+WHERE request_id = $1`
+	rows, err := r.pool.Query(ctx, q, requestID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return nil, pgx.ErrNoRows
+	}
+	item, err := scanLabOpenClawRun(rows)
+	if err != nil {
+		return nil, err
+	}
+	return &item, rows.Err()
+}
+
+func (r *Repository) InsertLabNote(ctx context.Context, note portfolio.LabNoteRequest) (*portfolio.LabNote, error) {
+	const q = `
+INSERT INTO lab_notes (signal_event_id, request_id, body)
+VALUES ($1, NULLIF($2, ''), $3)
+RETURNING id, signal_event_id, COALESCE(request_id, ''), body, created_at`
+	var out portfolio.LabNote
+	err := r.pool.QueryRow(ctx, q, note.SignalID, strings.TrimSpace(note.RequestID), strings.TrimSpace(note.Body)).Scan(
+		&out.ID,
+		&out.SignalID,
+		&out.RequestID,
+		&out.Body,
+		&out.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (r *Repository) ListLabTelemetry(ctx context.Context, symbol, window string) ([]portfolio.LabTelemetryPoint, error) {
+	const q = `
+SELECT date_trunc('minute', fired_at) AS bucket, symbol, avg(current_price), avg(delta_pct), avg(threshold_pct), count(*)
+FROM lab_signal_events
+WHERE fired_at >= now() - $1::interval
+  AND ($2 = '' OR symbol = $2)
+GROUP BY bucket, symbol
+ORDER BY bucket ASC, symbol ASC`
+	rows, err := r.pool.Query(ctx, q, window, strings.TrimSpace(symbol))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]portfolio.LabTelemetryPoint, 0)
+	for rows.Next() {
+		var item portfolio.LabTelemetryPoint
+		if err := rows.Scan(&item.Bucket, &item.Symbol, &item.CurrentPrice, &item.DeltaPct, &item.ThresholdPct, &item.SignalCount); err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) GetLabControlState(ctx context.Context) (*portfolio.LabControlState, error) {
+	const q = `
+SELECT openclaw_paused, circuit_open, circuit_reason, updated_at
+FROM lab_control_state
+WHERE singleton = TRUE`
+	var out portfolio.LabControlState
+	if err := r.pool.QueryRow(ctx, q).Scan(&out.OpenClawPaused, &out.CircuitOpen, &out.CircuitReason, &out.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (r *Repository) UpdateLabControlState(ctx context.Context, control portfolio.LabControlState) (*portfolio.LabControlState, error) {
+	const q = `
+INSERT INTO lab_control_state (singleton, openclaw_paused, circuit_open, circuit_reason, updated_at)
+VALUES (TRUE, $1, $2, $3, now())
+ON CONFLICT (singleton) DO UPDATE SET
+    openclaw_paused = EXCLUDED.openclaw_paused,
+    circuit_open = EXCLUDED.circuit_open,
+    circuit_reason = EXCLUDED.circuit_reason,
+    updated_at = now()
+RETURNING openclaw_paused, circuit_open, circuit_reason, updated_at`
+	var out portfolio.LabControlState
+	err := r.pool.QueryRow(ctx, q, control.OpenClawPaused, control.CircuitOpen, control.CircuitReason).Scan(
+		&out.OpenClawPaused,
+		&out.CircuitOpen,
+		&out.CircuitReason,
+		&out.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (r *Repository) InsertSignalSettingsVersion(ctx context.Context, req portfolio.SignalSettingsRequest, reason string) (*portfolio.SignalSettingsVersion, error) {
+	const q = `
+INSERT INTO signal_settings_versions (move_threshold_pct, cooldown, reason)
+VALUES ($1, $2, $3)
+RETURNING id, move_threshold_pct, cooldown, reason, created_at`
+	var out portfolio.SignalSettingsVersion
+	err := r.pool.QueryRow(ctx, q, req.MoveThresholdPct, req.Cooldown, strings.TrimSpace(reason)).Scan(
+		&out.ID,
+		&out.MoveThresholdPct,
+		&out.Cooldown,
+		&out.Reason,
+		&out.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (r *Repository) ListSignalSettingsVersions(ctx context.Context, limit int) ([]portfolio.SignalSettingsVersion, error) {
+	limit = clampLimit(limit, 10, 50)
+	const q = `
+SELECT id, move_threshold_pct, cooldown, reason, created_at
+FROM signal_settings_versions
+ORDER BY created_at DESC, id DESC
+LIMIT $1`
+	rows, err := r.pool.Query(ctx, q, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]portfolio.SignalSettingsVersion, 0, limit)
+	for rows.Next() {
+		var item portfolio.SignalSettingsVersion
+		if err := rows.Scan(&item.ID, &item.MoveThresholdPct, &item.Cooldown, &item.Reason, &item.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) RevertSignalSettings(ctx context.Context, versionID int64) (*portfolio.SignalSettings, error) {
+	const lookup = `SELECT move_threshold_pct, cooldown FROM signal_settings_versions WHERE id = $1`
+	var req portfolio.SignalSettingsRequest
+	if err := r.pool.QueryRow(ctx, lookup, versionID).Scan(&req.MoveThresholdPct, &req.Cooldown); err != nil {
+		return nil, err
+	}
+	if _, err := r.InsertSignalSettingsVersion(ctx, req, fmt.Sprintf("revert:%d", versionID)); err != nil {
+		return nil, err
+	}
+	if err := r.UpdateSignalSettings(ctx, req); err != nil {
+		return nil, err
+	}
+	return r.GetSignalSettings(ctx)
+}
+
+func (r *Repository) CompactLabOpenClawPayloads(ctx context.Context, olderThan time.Time) error {
+	const q = `
+UPDATE lab_openclaw_runs
+SET full_request_json = NULL,
+    full_response_json = NULL,
+    updated_at = now()
+WHERE updated_at < $1
+  AND (full_request_json IS NOT NULL OR full_response_json IS NOT NULL)`
+	_, err := r.pool.Exec(ctx, q, olderThan)
+	return err
+}
+
 func payloadJSONBytes(raw json.RawMessage) []byte {
 	if len(raw) == 0 {
 		return []byte(`{}`)
 	}
 	return raw
+}
+
+func nullableJSONBytes(raw json.RawMessage) []byte {
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanLabSignalEvent(row rowScanner) (portfolio.LabSignalEvent, error) {
+	var item portfolio.LabSignalEvent
+	err := row.Scan(
+		&item.ID,
+		&item.Type,
+		&item.Symbol,
+		&item.ProductID,
+		&item.Source,
+		&item.CurrentPrice,
+		&item.PreviousPrice,
+		&item.DeltaAmount,
+		&item.DeltaPct,
+		&item.ThresholdPct,
+		&item.FiredAt,
+		&item.PayloadJSON,
+		&item.DiscordStatus,
+		&item.CreatedAt,
+	)
+	return item, err
+}
+
+func scanLabOpenClawRun(row rowScanner) (portfolio.LabOpenClawRun, error) {
+	var item portfolio.LabOpenClawRun
+	var requestJSON []byte
+	var responseJSON []byte
+	err := row.Scan(
+		&item.RequestID,
+		&item.SignalID,
+		&item.Status,
+		&item.Attempts,
+		&item.Analysis,
+		&item.Recommendation,
+		&item.Confidence,
+		&item.ToolNames,
+		&item.ErrorText,
+		&item.RequestHash,
+		&item.ResponseHash,
+		&requestJSON,
+		&responseJSON,
+		&item.StartedAt,
+		&item.CompletedAt,
+		&item.CreatedAt,
+		&item.UpdatedAt,
+	)
+	if err != nil {
+		return portfolio.LabOpenClawRun{}, err
+	}
+	item.RequestJSON = json.RawMessage(requestJSON)
+	item.ResponseJSON = json.RawMessage(responseJSON)
+	return item, nil
+}
+
+func clampLimit(limit, fallback, max int) int {
+	if limit <= 0 {
+		return fallback
+	}
+	if limit > max {
+		return max
+	}
+	return limit
 }
 
 // CreateSession stores an opaque session token.

--- a/backend/internal/portfolio/repository.go
+++ b/backend/internal/portfolio/repository.go
@@ -21,6 +21,20 @@ type Repository interface {
 	UpdateSignalSettings(ctx context.Context, req SignalSettingsRequest) error
 	ListRecentAlerts(ctx context.Context, limit int) ([]RecentAlert, error)
 	InsertRecentAlert(ctx context.Context, alert RecentAlert) error
+	InsertLabSignalEvent(ctx context.Context, alert RecentAlert) (*LabSignalEvent, error)
+	ListLabSignalEvents(ctx context.Context, filter LabSignalFilter) ([]LabSignalEvent, error)
+	GetLabSignalEvent(ctx context.Context, id int64) (*LabSignalEvent, error)
+	UpsertLabOpenClawRun(ctx context.Context, run LabOpenClawRun) error
+	ListLabOpenClawRuns(ctx context.Context, filter LabRunFilter) ([]LabOpenClawRun, error)
+	GetLabOpenClawRun(ctx context.Context, requestID string) (*LabOpenClawRun, error)
+	InsertLabNote(ctx context.Context, note LabNoteRequest) (*LabNote, error)
+	ListLabTelemetry(ctx context.Context, symbol, window string) ([]LabTelemetryPoint, error)
+	GetLabControlState(ctx context.Context) (*LabControlState, error)
+	UpdateLabControlState(ctx context.Context, control LabControlState) (*LabControlState, error)
+	InsertSignalSettingsVersion(ctx context.Context, req SignalSettingsRequest, reason string) (*SignalSettingsVersion, error)
+	ListSignalSettingsVersions(ctx context.Context, limit int) ([]SignalSettingsVersion, error)
+	RevertSignalSettings(ctx context.Context, versionID int64) (*SignalSettings, error)
+	CompactLabOpenClawPayloads(ctx context.Context, olderThan time.Time) error
 
 	CreateSession(ctx context.Context, token, username string, expiresAt time.Time) error
 	SessionUser(ctx context.Context, token string) (username string, err error)

--- a/backend/internal/portfolio/types.go
+++ b/backend/internal/portfolio/types.go
@@ -113,6 +113,127 @@ type RecentAlertsResponse struct {
 	Alerts []RecentAlert `json:"alerts"`
 }
 
+// LabSignalEvent is the durable event record backing The Lab timeline.
+type LabSignalEvent struct {
+	ID            int64           `json:"id"`
+	Type          string          `json:"type"`
+	Symbol        string          `json:"symbol"`
+	ProductID     string          `json:"productId,omitempty"`
+	Source        string          `json:"source,omitempty"`
+	CurrentPrice  float64         `json:"currentPrice"`
+	PreviousPrice *float64        `json:"previousPrice,omitempty"`
+	DeltaAmount   *float64        `json:"deltaAmount,omitempty"`
+	DeltaPct      float64         `json:"deltaPct"`
+	ThresholdPct  float64         `json:"thresholdPct"`
+	FiredAt       time.Time       `json:"firedAt"`
+	PayloadJSON   json.RawMessage `json:"payloadJson,omitempty"`
+	DiscordStatus string          `json:"discordStatus"`
+	CreatedAt     time.Time       `json:"createdAt"`
+	Run           *LabOpenClawRun `json:"run,omitempty"`
+}
+
+type LabSignalFilter struct {
+	Limit  int
+	Symbol string
+	From   *time.Time
+	To     *time.Time
+}
+
+type LabSignalsResponse struct {
+	Signals []LabSignalEvent `json:"signals"`
+}
+
+type LabOpenClawRun struct {
+	RequestID      string          `json:"requestId"`
+	SignalID       int64           `json:"signalId"`
+	Status         string          `json:"status"`
+	Attempts       int             `json:"attempts"`
+	Analysis       string          `json:"analysis,omitempty"`
+	Recommendation string          `json:"recommendation,omitempty"`
+	Confidence     *float64        `json:"confidence,omitempty"`
+	ToolNames      []string        `json:"toolNames"`
+	ErrorText      string          `json:"errorText,omitempty"`
+	RequestHash    string          `json:"requestHash,omitempty"`
+	ResponseHash   string          `json:"responseHash,omitempty"`
+	RequestJSON    json.RawMessage `json:"requestJson,omitempty"`
+	ResponseJSON   json.RawMessage `json:"responseJson,omitempty"`
+	StartedAt      *time.Time      `json:"startedAt,omitempty"`
+	CompletedAt    *time.Time      `json:"completedAt,omitempty"`
+	CreatedAt      time.Time       `json:"createdAt"`
+	UpdatedAt      time.Time       `json:"updatedAt"`
+}
+
+type LabRunFilter struct {
+	Limit    int
+	Status   string
+	SignalID int64
+}
+
+type LabRunsResponse struct {
+	Runs []LabOpenClawRun `json:"runs"`
+}
+
+type LabControlState struct {
+	OpenClawPaused bool      `json:"openclawPaused"`
+	CircuitOpen    bool      `json:"circuitOpen"`
+	CircuitReason  string    `json:"circuitReason,omitempty"`
+	UpdatedAt      time.Time `json:"updatedAt"`
+}
+
+type LabOverviewResponse struct {
+	Control       LabControlState  `json:"control"`
+	RecentSignals []LabSignalEvent `json:"recentSignals"`
+	RecentRuns    []LabOpenClawRun `json:"recentRuns"`
+}
+
+type LabOperationResponse struct {
+	Control LabControlState `json:"control"`
+	Message string          `json:"message"`
+}
+
+type LabNote struct {
+	ID        int64     `json:"id"`
+	SignalID  *int64    `json:"signalId,omitempty"`
+	RequestID string    `json:"requestId,omitempty"`
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+type LabNoteRequest struct {
+	SignalID  *int64 `json:"signalId,omitempty"`
+	RequestID string `json:"requestId,omitempty"`
+	Body      string `json:"body"`
+}
+
+type LabTelemetryPoint struct {
+	Bucket       time.Time `json:"bucket"`
+	Symbol       string    `json:"symbol"`
+	CurrentPrice float64   `json:"currentPrice"`
+	DeltaPct     float64   `json:"deltaPct"`
+	ThresholdPct float64   `json:"thresholdPct"`
+	SignalCount  int       `json:"signalCount"`
+}
+
+type LabTelemetryResponse struct {
+	Points []LabTelemetryPoint `json:"points"`
+}
+
+type SignalSettingsVersion struct {
+	ID               int64     `json:"id"`
+	MoveThresholdPct float64   `json:"moveThresholdPct"`
+	Cooldown         string    `json:"cooldown"`
+	Reason           string    `json:"reason,omitempty"`
+	CreatedAt        time.Time `json:"createdAt"`
+}
+
+type SignalSettingsHistoryResponse struct {
+	Versions []SignalSettingsVersion `json:"versions"`
+}
+
+type SignalSettingsRevertRequest struct {
+	VersionID int64 `json:"versionId"`
+}
+
 // MapIngestToViews converts ingest snapshot positions into API views.
 func MapIngestToViews(req *IngestSnapshotRequest) PositionsResponse {
 	views := make([]PositionView, 0, len(req.Positions))

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,4 +4,5 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
-    command: npm run dev
+    # Keep the container-only node_modules volume in sync when package-lock changes.
+    command: sh -c "npm install && npm run dev"

--- a/frontend/app/lab/page.tsx
+++ b/frontend/app/lab/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { LabStatusCard } from "@/components/lab/lab-status-card";
+import { RunDetailPanel } from "@/components/lab/run-detail-panel";
+import { SignalRunTable } from "@/components/lab/signal-run-table";
+import { SignalSettingsLabCard } from "@/components/lab/signal-settings-lab-card";
+import { SignalTelemetryChart } from "@/components/lab/signal-telemetry-chart";
+import { SignalTimeline } from "@/components/lab/signal-timeline";
+import { SiteHeader } from "@/components/site-header";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  createLabNote,
+  fetchLabOverview,
+  fetchLabRuns,
+  fetchLabSignals,
+  fetchLabTelemetry,
+  pauseOpenClaw,
+  resetOpenClawCircuit,
+  resumeOpenClaw,
+  retryLabRun,
+  type LabControlState,
+  type LabOpenClawRun,
+  type LabSignalEvent,
+  type LabTelemetryPoint,
+} from "@/lib/lab-api";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export default function LabPage() {
+  const [control, setControl] = useState<LabControlState | null>(null);
+  const [signals, setSignals] = useState<LabSignalEvent[]>([]);
+  const [runs, setRuns] = useState<LabOpenClawRun[]>([]);
+  const [telemetry, setTelemetry] = useState<LabTelemetryPoint[]>([]);
+  const [selectedRun, setSelectedRun] = useState<LabOpenClawRun | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
+    setError(null);
+    try {
+      const [overview, signalResp, runResp, telemetryResp] = await Promise.all([
+        fetchLabOverview(),
+        fetchLabSignals(50),
+        fetchLabRuns(50),
+        fetchLabTelemetry("24h"),
+      ]);
+      setControl(overview.control);
+      setSignals(signalResp.signals ?? overview.recentSignals ?? []);
+      setRuns(runResp.runs ?? overview.recentRuns ?? []);
+      setTelemetry(telemetryResp.points ?? []);
+      setSelectedRun((current) => {
+        if (!current) return current;
+        return (runResp.runs ?? []).find((run) => run.requestId === current.requestId) ?? current;
+      });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load The Lab");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load(false);
+    const id = window.setInterval(() => void load(true), 30_000);
+    const onVis = () => {
+      if (document.visibilityState === "visible") void load(true);
+    };
+    document.addEventListener("visibilitychange", onVis);
+    return () => {
+      window.clearInterval(id);
+      document.removeEventListener("visibilitychange", onVis);
+    };
+  }, [load]);
+
+  const stats = useMemo(
+    () => [
+      { label: "Signals", value: String(signals.length), hint: "Last 50 qualifying events" },
+      { label: "Queued runs", value: String(runs.filter((run) => run.status === "queued" || run.status === "retrying").length), hint: "Waiting or retrying" },
+      { label: "Errors", value: String(runs.filter((run) => run.status === "failed").length), hint: "OpenClaw failures" },
+    ],
+    [runs, signals.length],
+  );
+
+  async function operate(action: "pause" | "resume" | "reset") {
+    const labels = { pause: "Pause OpenClaw forwarding?", resume: "Resume OpenClaw forwarding?", reset: "Reset OpenClaw circuit?" };
+    if (!window.confirm(labels[action])) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = action === "pause" ? await pauseOpenClaw() : action === "resume" ? await resumeOpenClaw() : await resetOpenClawCircuit();
+      setControl(res.control);
+      await load(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Operation failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function retry(run: LabOpenClawRun) {
+    setBusy(true);
+    setError(null);
+    try {
+      const next = await retryLabRun(run.requestId);
+      setSelectedRun(next);
+      await load(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Retry failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function saveNote(run: LabOpenClawRun, body: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      await createLabNote({ requestId: run.requestId, body });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save note");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <SiteHeader />
+      <main className="mx-auto max-w-6xl space-y-6 px-4 py-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">The Lab</h1>
+            <p className="text-sm text-muted-foreground">Crypto-first signal telemetry, OpenClaw operations, and experiment history.</p>
+          </div>
+          <Button type="button" variant="outline" disabled={loading || busy} onClick={() => void load(false)}>
+            Refresh
+          </Button>
+        </div>
+
+        {error ? <p className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">{error}</p> : null}
+
+        <div className="grid gap-4 md:grid-cols-3">
+          {stats.map((stat) => (
+            <Card key={stat.label}>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">{stat.label}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-semibold">{loading ? "..." : stat.value}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{stat.hint}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[1fr_0.9fr]">
+          <LabStatusCard
+            control={control}
+            busy={busy}
+            onPause={() => void operate("pause")}
+            onResume={() => void operate("resume")}
+            onResetCircuit={() => void operate("reset")}
+          />
+          <SignalSettingsLabCard onChanged={() => void load(true)} />
+        </div>
+
+        <SignalTelemetryChart points={telemetry} />
+
+        <div className="grid gap-6 xl:grid-cols-[1.4fr_0.8fr]">
+          <SignalRunTable signals={signals} runs={runs} onSelectRun={setSelectedRun} />
+          <RunDetailPanel run={selectedRun} busy={busy} onRetry={(run) => void retry(run)} onNote={(run, body) => void saveNote(run, body)} />
+        </div>
+
+        <SignalTimeline signals={signals} runs={runs} />
+      </main>
+    </div>
+  );
+}

--- a/frontend/components/lab/lab-status-card.tsx
+++ b/frontend/components/lab/lab-status-card.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { LabControlState } from "@/lib/lab-api";
+
+type Props = {
+  control: LabControlState | null;
+  busy?: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  onResetCircuit: () => void;
+};
+
+export function LabStatusCard({ control, busy, onPause, onResume, onResetCircuit }: Props) {
+  const paused = control?.openclawPaused ?? false;
+  const circuitOpen = control?.circuitOpen ?? false;
+
+  return (
+    <Card className="relative overflow-hidden border-border/70">
+      <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-cyan-400 via-sky-500 to-indigo-500" />
+      <CardHeader>
+        <CardTitle>OpenClaw operations</CardTitle>
+        <CardDescription>Observe and control signal forwarding without editing bot internals.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-3">
+          <StatusPill label="Forwarding" value={paused ? "Paused" : "Active"} tone={paused ? "warn" : "ok"} />
+          <StatusPill label="Circuit" value={circuitOpen ? "Open" : "Closed"} tone={circuitOpen ? "warn" : "ok"} />
+          <StatusPill label="Updated" value={control?.updatedAt ? new Date(control.updatedAt).toLocaleTimeString() : "n/a"} />
+        </div>
+        {control?.circuitReason ? <p className="text-sm text-muted-foreground">Circuit reason: {control.circuitReason}</p> : null}
+        <div className="flex flex-wrap gap-2">
+          {paused ? (
+            <Button type="button" disabled={busy} onClick={onResume}>
+              Resume forwarding
+            </Button>
+          ) : (
+            <Button type="button" variant="outline" disabled={busy} onClick={onPause}>
+              Pause forwarding
+            </Button>
+          )}
+          <Button type="button" variant="outline" disabled={busy || !circuitOpen} onClick={onResetCircuit}>
+            Reset circuit
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatusPill({ label, value, tone = "neutral" }: { label: string; value: string; tone?: "ok" | "warn" | "neutral" }) {
+  const toneClass =
+    tone === "ok"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+      : tone === "warn"
+        ? "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+        : "border-border bg-muted/30";
+  return (
+    <div className={`rounded-lg border p-3 ${toneClass}`}>
+      <p className="text-xs uppercase tracking-[0.16em] opacity-75">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/frontend/components/lab/run-detail-panel.tsx
+++ b/frontend/components/lab/run-detail-panel.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import type { LabOpenClawRun } from "@/lib/lab-api";
+import { useState } from "react";
+
+type Props = {
+  run: LabOpenClawRun | null;
+  busy?: boolean;
+  onRetry: (run: LabOpenClawRun) => void;
+  onNote: (run: LabOpenClawRun, body: string) => void;
+};
+
+export function RunDetailPanel({ run, busy, onRetry, onNote }: Props) {
+  const [note, setNote] = useState("");
+
+  if (!run) {
+    return (
+      <Card className="border-border/70">
+        <CardHeader>
+          <CardTitle>Run detail</CardTitle>
+          <CardDescription>Select a run to inspect the rationale and controls.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">No run selected.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader>
+        <CardTitle>Run detail</CardTitle>
+        <CardDescription>{run.requestId}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Metric label="Status" value={run.status} />
+          <Metric label="Attempts" value={String(run.attempts)} />
+          <Metric label="Confidence" value={run.confidence == null ? "n/a" : `${Math.round(run.confidence * 100)}%`} />
+        </div>
+        {run.recommendation ? (
+          <section>
+            <p className="text-sm font-medium">Recommendation</p>
+            <p className="mt-1 text-sm text-muted-foreground">{run.recommendation}</p>
+          </section>
+        ) : null}
+        {run.analysis ? (
+          <section>
+            <p className="text-sm font-medium">Rationale</p>
+            <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">{run.analysis}</p>
+          </section>
+        ) : null}
+        {run.errorText ? <p className="text-sm text-destructive">{run.errorText}</p> : null}
+        <section>
+          <p className="text-sm font-medium">Tools</p>
+          <p className="mt-1 text-sm text-muted-foreground">{run.toolNames?.length ? run.toolNames.join(", ") : "No tool calls recorded."}</p>
+        </section>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={busy}
+            onClick={() => {
+              if (window.confirm(`Retry ${run.requestId}?`)) onRetry(run);
+            }}
+          >
+            Retry run
+          </Button>
+        </div>
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Note</p>
+          <div className="flex gap-2">
+            <Input value={note} onChange={(e) => setNote(e.target.value)} placeholder="Add an observation for later analysis" />
+            <Button
+              type="button"
+              disabled={busy || note.trim() === ""}
+              onClick={() => {
+                onNote(run, note);
+                setNote("");
+              }}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border bg-muted/20 p-3">
+      <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">{label}</p>
+      <p className="mt-1 font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/frontend/components/lab/signal-run-table.tsx
+++ b/frontend/components/lab/signal-run-table.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import type { LabOpenClawRun, LabSignalEvent } from "@/lib/lab-api";
+
+type Props = {
+  signals: LabSignalEvent[];
+  runs: LabOpenClawRun[];
+  onSelectRun: (run: LabOpenClawRun) => void;
+};
+
+export function SignalRunTable({ signals, runs, onSelectRun }: Props) {
+  const runBySignal = new Map(runs.map((run) => [run.signalId, run]));
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader>
+        <CardTitle>Signals and responses</CardTitle>
+        <CardDescription>Qualifying signals, their current OpenClaw run state, and the Discord-gated alert history.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Time</TableHead>
+                <TableHead>Symbol</TableHead>
+                <TableHead>Move</TableHead>
+                <TableHead>Threshold</TableHead>
+                <TableHead>OpenClaw</TableHead>
+                <TableHead className="text-right">Action</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {signals.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="py-8 text-center text-sm text-muted-foreground">
+                    No Lab signals yet.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                signals.map((signal) => {
+                  const run = runBySignal.get(signal.id);
+                  return (
+                    <TableRow key={signal.id}>
+                      <TableCell className="whitespace-nowrap text-xs text-muted-foreground">{new Date(signal.firedAt).toLocaleString()}</TableCell>
+                      <TableCell className="font-medium">{signal.symbol}</TableCell>
+                      <TableCell>{fmtPct(signal.deltaPct)}</TableCell>
+                      <TableCell>{fmtPct(signal.thresholdPct)}</TableCell>
+                      <TableCell>
+                        <span className="rounded-full border px-2 py-1 text-xs">{run?.status ?? "not queued"}</span>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {run ? (
+                          <Button type="button" variant="outline" size="sm" onClick={() => onSelectRun(run)}>
+                            Details
+                          </Button>
+                        ) : null}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function fmtPct(value: number) {
+  return `${value >= 0 ? "+" : ""}${value.toFixed(2)}%`;
+}

--- a/frontend/components/lab/signal-settings-lab-card.tsx
+++ b/frontend/components/lab/signal-settings-lab-card.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { apiFetch } from "@/lib/api";
+import { fetchSignalSettingsHistory, revertSignalSettings, type SignalSettings, type SignalSettingsVersion } from "@/lib/lab-api";
+import { useEffect, useState } from "react";
+
+type Props = {
+  onChanged: () => void;
+};
+
+export function SignalSettingsLabCard({ onChanged }: Props) {
+  const [settings, setSettings] = useState<SignalSettings | null>(null);
+  const [versions, setVersions] = useState<SignalSettingsVersion[]>([]);
+  const [threshold, setThreshold] = useState("1.0");
+  const [cooldown, setCooldown] = useState("15m");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    setError(null);
+    try {
+      const [settingsRes, history] = await Promise.all([apiFetch("/api/trading/alert-settings"), fetchSignalSettingsHistory()]);
+      if (!settingsRes.ok) throw new Error(await settingsRes.text());
+      const next = (await settingsRes.json()) as SignalSettings;
+      setSettings(next);
+      setThreshold(String(next.moveThresholdPct ?? 1));
+      setCooldown(next.cooldown || "15m");
+      setVersions(history.versions ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load signal settings");
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await apiFetch("/api/trading/alert-settings", {
+        method: "PUT",
+        body: JSON.stringify({ moveThresholdPct: Number(threshold), cooldown }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setSettings((await res.json()) as SignalSettings);
+      await load();
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save signal settings");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function revert(version: SignalSettingsVersion) {
+    if (!window.confirm(`Revert to ${version.moveThresholdPct}% / ${version.cooldown}?`)) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const next = await revertSignalSettings(version.id);
+      setSettings(next);
+      setThreshold(String(next.moveThresholdPct));
+      setCooldown(next.cooldown);
+      await load();
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to revert signal settings");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader>
+        <CardTitle>Signal filters</CardTitle>
+        <CardDescription>Live settings used by the signals service on each tick.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="space-y-2">
+            <span className="text-sm font-medium">Minimum move</span>
+            <Input type="number" step="0.1" min="0.1" value={threshold} onChange={(e) => setThreshold(e.target.value)} />
+          </label>
+          <label className="space-y-2">
+            <span className="text-sm font-medium">Cooldown</span>
+            <Input value={cooldown} onChange={(e) => setCooldown(e.target.value)} placeholder="15m" />
+          </label>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button type="button" disabled={saving} onClick={() => void save()}>
+            {saving ? "Saving..." : "Save filters"}
+          </Button>
+          <Button type="button" variant="outline" disabled={saving} onClick={() => void load()}>
+            Refresh
+          </Button>
+          {settings?.updatedAt ? <span className="text-xs text-muted-foreground">Updated {new Date(settings.updatedAt).toLocaleString()}</span> : null}
+        </div>
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        <div className="rounded-lg border bg-muted/20 p-3">
+          <p className="text-sm font-medium">Last known versions</p>
+          {versions.length === 0 ? (
+            <p className="mt-1 text-sm text-muted-foreground">No saved versions yet.</p>
+          ) : (
+            <ul className="mt-2 space-y-2">
+              {versions.slice(0, 5).map((version) => (
+                <li key={version.id} className="flex items-center justify-between gap-3 text-sm">
+                  <span>
+                    {version.moveThresholdPct}% / {version.cooldown}
+                    <span className="ml-2 text-xs text-muted-foreground">{new Date(version.createdAt).toLocaleString()}</span>
+                  </span>
+                  <Button type="button" size="sm" variant="outline" disabled={saving} onClick={() => void revert(version)}>
+                    Revert
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/lab/signal-telemetry-chart.tsx
+++ b/frontend/components/lab/signal-telemetry-chart.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { LabTelemetryPoint } from "@/lib/lab-api";
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+type Props = {
+  points: LabTelemetryPoint[];
+};
+
+export function SignalTelemetryChart({ points }: Props) {
+  const data = points.map((point) => ({
+    ...point,
+    time: new Date(point.bucket).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+  }));
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader>
+        <CardTitle>Signal telemetry</CardTitle>
+        <CardDescription>Price moves and thresholds over the selected window.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <div className="flex h-[260px] items-center justify-center rounded-lg border border-dashed text-sm text-muted-foreground">
+            No telemetry yet. Qualifying signals will draw this chart.
+          </div>
+        ) : (
+          <div className="h-[300px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={data} margin={{ left: 8, right: 16, top: 8, bottom: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                <XAxis dataKey="time" tickLine={false} axisLine={false} fontSize={12} />
+                <YAxis tickLine={false} axisLine={false} fontSize={12} />
+                <Tooltip
+                  contentStyle={{
+                    background: "hsl(var(--card))",
+                    border: "1px solid hsl(var(--border))",
+                    borderRadius: "0.5rem",
+                  }}
+                />
+                <Line type="monotone" dataKey="deltaPct" name="Move %" stroke="hsl(var(--chart-1))" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="thresholdPct" name="Threshold %" stroke="hsl(var(--chart-2))" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="currentPrice" name="Price" stroke="hsl(var(--chart-3))" strokeWidth={1.5} dot={false} yAxisId={0} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/lab/signal-timeline.tsx
+++ b/frontend/components/lab/signal-timeline.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { LabOpenClawRun, LabSignalEvent } from "@/lib/lab-api";
+
+type Props = {
+  signals: LabSignalEvent[];
+  runs: LabOpenClawRun[];
+};
+
+export function SignalTimeline({ signals, runs }: Props) {
+  const runBySignal = new Map(runs.map((run) => [run.signalId, run]));
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader>
+        <CardTitle>Timeline</CardTitle>
+        <CardDescription>Recent qualifying signals and their Lab response state.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {signals.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No signal timeline yet.</p>
+        ) : (
+          <ol className="relative space-y-4 border-l pl-5">
+            {signals.slice(0, 12).map((signal) => {
+              const run = runBySignal.get(signal.id);
+              return (
+                <li key={signal.id} className="relative">
+                  <span className="absolute -left-[1.8rem] top-1 h-3 w-3 rounded-full border bg-background" />
+                  <div className="rounded-lg border bg-muted/20 p-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold">
+                          {signal.symbol} {signal.deltaPct >= 0 ? "+" : ""}
+                          {signal.deltaPct.toFixed(2)}%
+                        </p>
+                        <p className="text-xs text-muted-foreground">{new Date(signal.firedAt).toLocaleString()}</p>
+                      </div>
+                      <span className="rounded-full border px-2 py-1 text-xs">{run?.status ?? "not queued"}</span>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      Discord: {signal.discordStatus || "signal_only"}; threshold {signal.thresholdPct.toFixed(2)}%
+                    </p>
+                    {run?.recommendation ? <p className="mt-2 text-sm">{run.recommendation}</p> : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/site-header.tsx
+++ b/frontend/components/site-header.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { apiFetch, clearCrossOriginBearerToken } from "@/lib/api";
+import { clearSessionMarker } from "@/lib/auth";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import { Button } from "@/components/ui/button";
-import { clearSessionMarker } from "@/lib/auth";
-import { apiFetch, clearCrossOriginBearerToken } from "@/lib/api";
+import Link from "next/link";
 
 export function SiteHeader() {
   const { theme, setTheme } = useTheme();
@@ -24,9 +24,19 @@ export function SiteHeader() {
   return (
     <header className="border-b bg-card">
       <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3">
-        <Link href="/" className="text-lg font-semibold tracking-tight">
-          Morgans D. Stonks
-        </Link>
+        <div className="flex items-center gap-4">
+          <Link href="/" className="text-lg font-semibold tracking-tight">
+            Morgans D. Stonks
+          </Link>
+          <nav className="flex items-center gap-1 text-sm">
+            <Button asChild variant="ghost" size="sm">
+              <Link href="/">Portfolio</Link>
+            </Button>
+            <Button asChild variant="ghost" size="sm">
+              <Link href="/lab">The Lab</Link>
+            </Button>
+          </nav>
+        </div>
         <div className="flex items-center gap-2">
           <Button
             type="button"

--- a/frontend/lib/lab-api.test.ts
+++ b/frontend/lib/lab-api.test.ts
@@ -1,0 +1,21 @@
+import type { LabSignalEvent } from "@/lib/lab-api";
+import { describe, expect, it } from "vitest";
+
+describe("lab api types", () => {
+  it("keeps durable signal fields explicit", () => {
+    const signal: LabSignalEvent = {
+      id: 1,
+      type: "crypto_price_move",
+      symbol: "BTC-USD",
+      currentPrice: 100,
+      deltaPct: 1.25,
+      thresholdPct: 1,
+      firedAt: "2026-01-01T00:00:00Z",
+      discordStatus: "signal_only",
+      createdAt: "2026-01-01T00:00:01Z",
+    };
+
+    expect(signal.symbol).toBe("BTC-USD");
+    expect(signal.discordStatus).toBe("signal_only");
+  });
+});

--- a/frontend/lib/lab-api.ts
+++ b/frontend/lib/lab-api.ts
@@ -1,0 +1,123 @@
+import { apiFetch } from "@/lib/api";
+
+export type LabControlState = {
+  openclawPaused: boolean;
+  circuitOpen: boolean;
+  circuitReason?: string;
+  updatedAt: string;
+};
+
+export type LabSignalEvent = {
+  id: number;
+  type: string;
+  symbol: string;
+  productId?: string;
+  source?: string;
+  currentPrice: number;
+  previousPrice?: number | null;
+  deltaAmount?: number | null;
+  deltaPct: number;
+  thresholdPct: number;
+  firedAt: string;
+  discordStatus: string;
+  createdAt: string;
+};
+
+export type LabOpenClawRun = {
+  requestId: string;
+  signalId: number;
+  status: string;
+  attempts: number;
+  analysis?: string;
+  recommendation?: string;
+  confidence?: number | null;
+  toolNames: string[];
+  errorText?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type LabOverview = {
+  control: LabControlState;
+  recentSignals: LabSignalEvent[];
+  recentRuns: LabOpenClawRun[];
+};
+
+export type LabTelemetryPoint = {
+  bucket: string;
+  symbol: string;
+  currentPrice: number;
+  deltaPct: number;
+  thresholdPct: number;
+  signalCount: number;
+};
+
+export type SignalSettings = {
+  moveThresholdPct: number;
+  cooldown: string;
+  updatedAt?: string;
+};
+
+export type SignalSettingsVersion = {
+  id: number;
+  moveThresholdPct: number;
+  cooldown: string;
+  reason?: string;
+  createdAt: string;
+};
+
+async function readJSON<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return (await res.json()) as T;
+}
+
+export async function fetchLabOverview() {
+  return readJSON<LabOverview>(await apiFetch("/api/lab/overview"));
+}
+
+export async function fetchLabSignals(limit = 50) {
+  return readJSON<{ signals: LabSignalEvent[] }>(await apiFetch(`/api/lab/signals?limit=${limit}`));
+}
+
+export async function fetchLabRuns(limit = 50) {
+  return readJSON<{ runs: LabOpenClawRun[] }>(await apiFetch(`/api/lab/runs?limit=${limit}`));
+}
+
+export async function fetchLabTelemetry(window = "24h") {
+  return readJSON<{ points: LabTelemetryPoint[] }>(await apiFetch(`/api/lab/telemetry?window=${encodeURIComponent(window)}`));
+}
+
+export async function pauseOpenClaw() {
+  return readJSON<{ control: LabControlState; message: string }>(await apiFetch("/api/lab/openclaw/pause", { method: "POST" }));
+}
+
+export async function resumeOpenClaw() {
+  return readJSON<{ control: LabControlState; message: string }>(await apiFetch("/api/lab/openclaw/resume", { method: "POST" }));
+}
+
+export async function resetOpenClawCircuit() {
+  return readJSON<{ control: LabControlState; message: string }>(await apiFetch("/api/lab/openclaw/circuit/reset", { method: "POST" }));
+}
+
+export async function retryLabRun(requestId: string) {
+  return readJSON<LabOpenClawRun>(await apiFetch(`/api/lab/runs/${encodeURIComponent(requestId)}/retry`, { method: "POST" }));
+}
+
+export async function createLabNote(body: { signalId?: number; requestId?: string; body: string }) {
+  return readJSON(await apiFetch("/api/lab/notes", { method: "POST", body: JSON.stringify(body) }));
+}
+
+export async function fetchSignalSettingsHistory() {
+  return readJSON<{ versions: SignalSettingsVersion[] }>(await apiFetch("/api/lab/signal-settings/history?limit=10"));
+}
+
+export async function revertSignalSettings(versionId: number) {
+  return readJSON<SignalSettings>(
+    await apiFetch("/api/lab/signal-settings/revert", {
+      method: "POST",
+      body: JSON.stringify({ versionId }),
+    }),
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "postcss": "^8",
         "react": "^18",
         "react-dom": "^18",
+        "recharts": "^3.8.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^3.4.17",
         "tailwindcss-animate": "^1.0.7",
@@ -1620,6 +1621,40 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.3",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
@@ -1957,6 +1992,16 @@
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1974,6 +2019,60 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2026,6 +2125,11 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.3",
@@ -3349,6 +3453,116 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3422,6 +3636,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
@@ -3707,6 +3926,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -4160,6 +4384,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -4648,6 +4877,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4685,6 +4923,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6214,8 +6460,29 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -6234,6 +6501,45 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6277,6 +6583,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -7063,6 +7374,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7418,10 +7734,39 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@types/node": "^22.15.29",
     "autoprefixer": "^10.4.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -24,11 +25,11 @@
     "postcss": "^8",
     "react": "^18",
     "react-dom": "^18",
+    "recharts": "^3.8.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5",
-    "@types/node": "^22.15.29"
+    "typescript": "^5"
   },
   "devDependencies": {
     "@types/react": "^18",


### PR DESCRIPTION
## Summary
- Add durable Lab storage for qualifying crypto signals, OpenClaw run telemetry, notes, signal settings versions, and operational control state.
- Add session APIs for The Lab plus pause/resume, circuit reset, retry, signal settings history/revert, and telemetry polling.
- Add the `/lab` dashboard with charts, signal/run tables, timeline, run details, notes, and dev compose dependency sync.

## Test plan
- `cd backend && go test ./...`
- `cd frontend && nvm use 22.22.0 && npm test && npm run build`
- Recreated local `web` service and confirmed `recharts` is present in-container.


Made with [Cursor](https://cursor.com)